### PR TITLE
feat: checkpoint race mode

### DIFF
--- a/src/game/CheckpointManager.ts
+++ b/src/game/CheckpointManager.ts
@@ -1,0 +1,158 @@
+import { Container, Graphics } from 'pixi.js';
+import { Vector2 } from '../utils/Vector2';
+import { BloomFilter } from '../rendering/BloomFilter';
+
+export interface Checkpoint {
+  position: Vector2;
+  collected: boolean;
+  index: number;
+}
+
+export class CheckpointManager {
+  readonly container: Container;
+  private checkpoints: Checkpoint[] = [];
+  private currentIndex = 0;
+  private graphics: Graphics[] = [];
+  private bloom: BloomFilter;
+  private time = 0;
+
+  private readonly collectionRadius = 80;
+  private readonly gateRadius = 30;
+  private readonly neonCyan = 0x00ffff;
+  private readonly neonMagenta = 0xff00ff;
+
+  constructor(bloom: BloomFilter) {
+    this.container = new Container();
+    this.bloom = bloom;
+  }
+
+  generateCircuit(): void {
+    // Clear previous
+    this.container.removeChildren();
+    this.graphics = [];
+    this.checkpoints = [];
+    this.currentIndex = 0;
+
+    // Place 10 checkpoints in a rough loop circuit around spawn (0,0).
+    // The main road runs roughly along y = mainRoadY(x).
+    // We lay checkpoints along a circuit that goes right along the road,
+    // veers into the desert, loops back left, and returns.
+    const waypoints: [number, number][] = [
+      [400, 0],       // 1: right on road
+      [1000, -60],    // 2: further right on road
+      [1800, -120],   // 3: far right curve
+      [2200, -400],   // 4: off-road into desert (north)
+      [1800, -800],   // 5: deep desert
+      [1000, -900],   // 6: far north
+      [200, -700],    // 7: heading back west
+      [-400, -400],   // 8: southwest of start
+      [-600, 0],      // 9: west on road
+      [-200, 200],    // 10: loop back to start area
+    ];
+
+    for (let i = 0; i < waypoints.length; i++) {
+      const [x, y] = waypoints[i];
+      const checkpoint: Checkpoint = {
+        position: new Vector2(x, y),
+        collected: false,
+        index: i,
+      };
+      this.checkpoints.push(checkpoint);
+
+      const gfx = new Graphics();
+      this.drawCheckpoint(gfx, false, false);
+      gfx.position.set(x, y);
+      this.bloom.applyTo(gfx, 0.6, 2);
+      this.container.addChild(gfx);
+      this.graphics.push(gfx);
+    }
+  }
+
+  update(dt: number, vehiclePosition: Vector2): boolean {
+    this.time += dt;
+
+    if (this.currentIndex >= this.checkpoints.length) return false;
+
+    const cp = this.checkpoints[this.currentIndex];
+    const dx = vehiclePosition.x - cp.position.x;
+    const dy = vehiclePosition.y - cp.position.y;
+    const distSq = dx * dx + dy * dy;
+
+    let collected = false;
+    if (distSq < this.collectionRadius * this.collectionRadius) {
+      cp.collected = true;
+      this.currentIndex++;
+      collected = true;
+    }
+
+    // Redraw all checkpoints to update pulsing and collected state
+    for (let i = 0; i < this.checkpoints.length; i++) {
+      const checkpoint = this.checkpoints[i];
+      const isNext = i === this.currentIndex;
+      this.drawCheckpoint(this.graphics[i], checkpoint.collected, isNext);
+      this.graphics[i].visible = !checkpoint.collected;
+    }
+
+    return collected;
+  }
+
+  private drawCheckpoint(gfx: Graphics, collected: boolean, isNext: boolean): void {
+    gfx.clear();
+
+    if (collected) return;
+
+    const pulse = Math.sin(this.time * 3) * 0.3 + 0.7;
+    const color = isNext ? this.neonMagenta : this.neonCyan;
+    const radius = this.gateRadius;
+
+    // Outer ring (glow)
+    gfx.beginFill(color, 0.1 * pulse);
+    gfx.drawCircle(0, 0, radius + 12);
+    gfx.endFill();
+
+    // Main ring
+    gfx.lineStyle(3, color, 0.8 * pulse);
+    gfx.drawCircle(0, 0, radius);
+
+    // Inner ring
+    gfx.lineStyle(2, color, 0.4 * pulse);
+    gfx.drawCircle(0, 0, radius * 0.6);
+
+    // Center dot
+    gfx.beginFill(color, 0.6 * pulse);
+    gfx.drawCircle(0, 0, 4);
+    gfx.endFill();
+  }
+
+  getNextCheckpoint(): Checkpoint | null {
+    if (this.currentIndex >= this.checkpoints.length) return null;
+    return this.checkpoints[this.currentIndex];
+  }
+
+  getCurrentIndex(): number {
+    return this.currentIndex;
+  }
+
+  getTotal(): number {
+    return this.checkpoints.length;
+  }
+
+  isComplete(): boolean {
+    return this.currentIndex >= this.checkpoints.length;
+  }
+
+  reset(): void {
+    this.currentIndex = 0;
+    this.time = 0;
+    for (const cp of this.checkpoints) {
+      cp.collected = false;
+    }
+    for (const gfx of this.graphics) {
+      gfx.visible = true;
+    }
+  }
+
+  getCheckpoints(): Checkpoint[] {
+    return this.checkpoints;
+  }
+}

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -2,6 +2,8 @@ import { Container } from 'pixi.js';
 import type { Application } from 'pixi.js';
 import { GAME_CONFIG } from './GameConfig';
 import { InputManager } from './InputManager';
+import { RaceMode, RaceState } from './RaceMode';
+import { CheckpointManager } from './CheckpointManager';
 import { Vehicle } from '../vehicle/Vehicle';
 import { SurfaceType, getSurfaceFriction } from '../physics/SurfaceTypes';
 import { Camera } from '../rendering/Camera';
@@ -35,6 +37,8 @@ export class Game {
   private headlights: Headlights;
   private audio: AudioManager;
   private collisions: CollisionSystem;
+  private raceMode: RaceMode;
+  private checkpoints: CheckpointManager;
   private accumulator = 0;
 
   private camera: Camera;
@@ -45,6 +49,7 @@ export class Game {
 
   private currentSurface: SurfaceType = SurfaceType.Road;
   private driftScore = 0;
+  private lastRaceState: RaceState = RaceState.TITLE;
 
   constructor(app: Application) {
     this.app = app;
@@ -69,11 +74,18 @@ export class Game {
     this.miniMap = new MiniMap();
     this.touchControls = new TouchControls();
 
-    // Add world elements
-    this.world.addChild(this.terrainLayer, this.trackLayer, this.vehicle.container, this.particleLayer);
-    this.app.stage.addChild(this.world);
-
     this.bloom = new BloomFilter();
+
+    // Checkpoint system (added to world before vehicle for layering)
+    this.checkpoints = new CheckpointManager(this.bloom);
+    this.checkpoints.generateCircuit();
+
+    // Race mode state machine
+    this.raceMode = new RaceMode();
+
+    // Add world elements
+    this.world.addChild(this.terrainLayer, this.trackLayer, this.checkpoints.container, this.vehicle.container, this.particleLayer);
+    this.app.stage.addChild(this.world);
     this.headlights = new Headlights();
     this.lighting = new LightingSystem(this.app.renderer.width, this.app.renderer.height);
     this.lighting.addLight(this.headlights.container);
@@ -170,6 +182,20 @@ export class Game {
 
   private update = (): void => {
     const dt = this.app.ticker.deltaMS / 1000;
+
+    // Update race mode state machine
+    this.raceMode.update(dt);
+
+    // Reset vehicle when transitioning to READY state
+    if (this.raceMode.state === RaceState.READY && this.lastRaceState !== RaceState.READY) {
+      this.vehicle.model.position.set(0, 0);
+      this.vehicle.model.velocity.set(0, 0);
+      this.vehicle.model.heading = 0;
+      this.vehicle.model.yawRate = 0;
+      this.checkpoints.reset();
+    }
+    this.lastRaceState = this.raceMode.state;
+
     this.accumulator = Math.min(
       this.accumulator + dt,
       GAME_CONFIG.physicsStep * GAME_CONFIG.maxSubSteps
@@ -180,7 +206,12 @@ export class Game {
     this.input.setTouchInput(touchInput);
 
     while (this.accumulator >= GAME_CONFIG.physicsStep) {
-      const input = this.input.getInput();
+      // Only process vehicle input during racing
+      const rawInput = this.input.getInput();
+      const input = this.raceMode.inputEnabled
+        ? rawInput
+        : { throttle: 0, brake: 0, steer: 0, handbrake: 0 };
+
       this.currentSurface = this.getSurfaceAt(this.vehicle.model.position.x, this.vehicle.model.position.y);
       const friction = getSurfaceFriction(this.currentSurface);
       this.vehicle.update(GAME_CONFIG.physicsStep, input, friction);
@@ -192,6 +223,20 @@ export class Game {
       } else if (this.vehicle.driftPhase === 'Normal') {
         this.driftScore = 0;
       }
+    }
+
+    // Checkpoint detection during racing
+    if (this.raceMode.state === RaceState.RACING) {
+      const collected = this.checkpoints.update(dt, this.vehicle.model.position);
+      if (collected) {
+        this.hud.triggerCheckpointFlash();
+        if (this.checkpoints.isComplete()) {
+          this.raceMode.finish();
+        }
+      }
+    } else {
+      // Still update checkpoint visuals (pulsing) even when not racing
+      this.checkpoints.update(dt, new Vector2(-99999, -99999));
     }
 
     // Collision detection
@@ -213,7 +258,7 @@ export class Game {
 
     // Screen shake
     const shake = this.collisions.updateShake(dt);
-    
+
     const velocity = this.vehicle.model.velocity;
     this.camera.update(
       this.vehicle.model.position.x,
@@ -259,6 +304,26 @@ export class Game {
       driftScore: this.driftScore,
       surfaceType: this.currentSurface,
     });
+
+    // Update Race HUD
+    const nextCp = this.checkpoints.getNextCheckpoint();
+    let arrowAngle: number | null = null;
+    if (nextCp) {
+      const dx = nextCp.position.x - this.vehicle.model.position.x;
+      const dy = nextCp.position.y - this.vehicle.model.position.y;
+      arrowAngle = Math.atan2(dy, dx);
+    }
+
+    this.hud.updateRace({
+      raceState: this.raceMode.state,
+      raceTime: this.raceMode.raceTime,
+      formattedTime: this.raceMode.formatTime(this.raceMode.raceTime),
+      checkpointCurrent: this.checkpoints.getCurrentIndex(),
+      checkpointTotal: this.checkpoints.getTotal(),
+      countdownValue: this.raceMode.countdownValue,
+      bestTime: this.raceMode.bestTime !== null ? this.raceMode.formatTime(this.raceMode.bestTime) : null,
+      arrowAngle,
+    }, dt);
 
     // Update audio
     this.audio.update({

--- a/src/game/RaceMode.ts
+++ b/src/game/RaceMode.ts
@@ -1,0 +1,130 @@
+export enum RaceState {
+  TITLE = 'TITLE',
+  READY = 'READY',
+  COUNTDOWN = 'COUNTDOWN',
+  RACING = 'RACING',
+  FINISHED = 'FINISHED',
+}
+
+const BEST_TIME_KEY = 'ndo-best-time';
+
+export class RaceMode {
+  state: RaceState = RaceState.TITLE;
+  raceTime = 0;
+  countdownTimer = 0;
+  countdownValue = 3;
+  bestTime: number | null = null;
+  private enterPressed = false;
+  private enterWasDown = false;
+
+  constructor() {
+    this.loadBestTime();
+    window.addEventListener('keydown', this.onKeyDown);
+    window.addEventListener('keyup', this.onKeyUp);
+  }
+
+  private onKeyDown = (e: KeyboardEvent): void => {
+    if (e.code === 'Enter') {
+      this.enterPressed = true;
+    }
+  };
+
+  private onKeyUp = (e: KeyboardEvent): void => {
+    if (e.code === 'Enter') {
+      this.enterPressed = false;
+    }
+  };
+
+  /** Returns true on the frame Enter is newly pressed (edge detection). */
+  private consumeEnter(): boolean {
+    const pressed = this.enterPressed && !this.enterWasDown;
+    this.enterWasDown = this.enterPressed;
+    return pressed;
+  }
+
+  update(dt: number): void {
+    const enterJustPressed = this.consumeEnter();
+
+    switch (this.state) {
+      case RaceState.TITLE:
+        if (enterJustPressed) {
+          this.state = RaceState.READY;
+        }
+        break;
+
+      case RaceState.READY:
+        if (enterJustPressed) {
+          this.state = RaceState.COUNTDOWN;
+          this.countdownTimer = 3;
+          this.countdownValue = 3;
+          this.raceTime = 0;
+        }
+        break;
+
+      case RaceState.COUNTDOWN:
+        this.countdownTimer -= dt;
+        this.countdownValue = Math.ceil(this.countdownTimer);
+        if (this.countdownTimer <= 0) {
+          this.state = RaceState.RACING;
+          this.countdownValue = 0;
+        }
+        break;
+
+      case RaceState.RACING:
+        this.raceTime += dt;
+        break;
+
+      case RaceState.FINISHED:
+        if (enterJustPressed) {
+          this.state = RaceState.READY;
+        }
+        break;
+    }
+  }
+
+  finish(): void {
+    if (this.state !== RaceState.RACING) return;
+    this.state = RaceState.FINISHED;
+
+    if (this.bestTime === null || this.raceTime < this.bestTime) {
+      this.bestTime = this.raceTime;
+      this.saveBestTime();
+    }
+  }
+
+  /** Whether vehicle input should be active. */
+  get inputEnabled(): boolean {
+    return this.state === RaceState.RACING;
+  }
+
+  formatTime(seconds: number): string {
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    const ms = Math.floor((seconds % 1) * 100);
+    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}.${ms.toString().padStart(2, '0')}`;
+  }
+
+  private loadBestTime(): void {
+    try {
+      const stored = localStorage.getItem(BEST_TIME_KEY);
+      if (stored !== null) {
+        const parsed = parseFloat(stored);
+        if (!isNaN(parsed) && parsed > 0) {
+          this.bestTime = parsed;
+        }
+      }
+    } catch {
+      // localStorage may not be available
+    }
+  }
+
+  private saveBestTime(): void {
+    try {
+      if (this.bestTime !== null) {
+        localStorage.setItem(BEST_TIME_KEY, this.bestTime.toString());
+      }
+    } catch {
+      // localStorage may not be available
+    }
+  }
+}

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -2,6 +2,7 @@ import { Container, Graphics, Text, TextStyle } from 'pixi.js';
 import { DriftPhase } from '../physics/DriftState';
 import { SurfaceType } from '../physics/SurfaceTypes';
 import { clamp } from '../utils/MathUtils';
+import { RaceState } from '../game/RaceMode';
 
 export interface HUDState {
   speed: number; // m/s
@@ -9,6 +10,17 @@ export interface HUDState {
   driftPhase: DriftPhase;
   driftScore: number;
   surfaceType: SurfaceType;
+}
+
+export interface RaceHUDState {
+  raceState: RaceState;
+  raceTime: number;
+  formattedTime: string;
+  checkpointCurrent: number;
+  checkpointTotal: number;
+  countdownValue: number;
+  bestTime: string | null;
+  arrowAngle: number | null; // angle from vehicle to next checkpoint in radians, null if no target
 }
 
 export class HUD {
@@ -32,6 +44,22 @@ export class HUD {
   private surfaceContainer: Container;
   private surfaceIcon: Graphics;
   private surfaceLabel: Text;
+
+  // Race HUD elements
+  private raceTimerContainer: Container;
+  private raceTimerText: Text;
+  private checkpointText: Text;
+  private arrowGraphics: Graphics;
+  private overlayContainer: Container;
+  private overlayBg: Graphics;
+  private overlayTitle: Text;
+  private overlaySubtitle: Text;
+  private overlayBest: Text;
+  private countdownText: Text;
+  private flashGraphics: Graphics;
+  private flashAlpha = 0;
+  private soundHintText: Text;
+  private soundHintTimer = 4;
 
   private readonly neonCyan = 0x00ffff;
   private readonly neonMagenta = 0xff00ff;
@@ -61,15 +89,36 @@ export class HUD {
     this.surfaceIcon = new Graphics();
     this.surfaceLabel = new Text({ text: 'ROAD', style: this.createLabelStyle() });
 
+    // Race HUD
+    this.raceTimerContainer = new Container();
+    this.raceTimerText = new Text({ text: '00:00.00', style: this.createTimerStyle() });
+    this.checkpointText = new Text({ text: '', style: this.createCheckpointStyle() });
+    this.arrowGraphics = new Graphics();
+    this.overlayContainer = new Container();
+    this.overlayBg = new Graphics();
+    this.overlayTitle = new Text({ text: '', style: this.createOverlayTitleStyle() });
+    this.overlaySubtitle = new Text({ text: '', style: this.createOverlaySubtitleStyle() });
+    this.overlayBest = new Text({ text: '', style: this.createOverlayBestStyle() });
+    this.countdownText = new Text({ text: '', style: this.createCountdownStyle() });
+    this.flashGraphics = new Graphics();
+    this.soundHintText = new Text({ text: 'Press M for sound', style: this.createLabelStyle() });
+
     this.setupSpeedDisplay();
     this.setupRPMDisplay();
     this.setupDriftDisplay();
     this.setupSurfaceDisplay();
+    this.setupRaceHUD();
 
     this.container.addChild(this.speedContainer);
     this.container.addChild(this.rpmContainer);
     this.container.addChild(this.driftContainer);
     this.container.addChild(this.surfaceContainer);
+    this.container.addChild(this.raceTimerContainer);
+    this.container.addChild(this.arrowGraphics);
+    this.container.addChild(this.flashGraphics);
+    this.container.addChild(this.overlayContainer);
+    this.container.addChild(this.countdownText);
+    this.container.addChild(this.soundHintText);
 
     // Initially hide drift display
     this.driftContainer.visible = false;
@@ -291,6 +340,239 @@ export class HUD {
     }
   }
 
+  private createTimerStyle(): TextStyle {
+    return new TextStyle({
+      fontFamily: 'monospace',
+      fontSize: 32,
+      fontWeight: 'bold',
+      fill: 0xffffff,
+      dropShadow: {
+        color: this.neonCyan,
+        blur: 6,
+        distance: 0,
+      },
+    });
+  }
+
+  private createCheckpointStyle(): TextStyle {
+    return new TextStyle({
+      fontFamily: 'monospace',
+      fontSize: 18,
+      fill: this.neonCyan,
+    });
+  }
+
+  private createOverlayTitleStyle(): TextStyle {
+    return new TextStyle({
+      fontFamily: 'monospace',
+      fontSize: 56,
+      fontWeight: 'bold',
+      fill: this.neonCyan,
+      dropShadow: {
+        color: this.neonCyan,
+        blur: 16,
+        distance: 0,
+      },
+    });
+  }
+
+  private createOverlaySubtitleStyle(): TextStyle {
+    return new TextStyle({
+      fontFamily: 'monospace',
+      fontSize: 20,
+      fill: 0xcccccc,
+    });
+  }
+
+  private createOverlayBestStyle(): TextStyle {
+    return new TextStyle({
+      fontFamily: 'monospace',
+      fontSize: 18,
+      fill: this.neonMagenta,
+    });
+  }
+
+  private createCountdownStyle(): TextStyle {
+    return new TextStyle({
+      fontFamily: 'monospace',
+      fontSize: 96,
+      fontWeight: 'bold',
+      fill: 0xffffff,
+      dropShadow: {
+        color: this.neonMagenta,
+        blur: 20,
+        distance: 0,
+      },
+    });
+  }
+
+  private setupRaceHUD(): void {
+    // Timer panel (top center)
+    const timerPanel = new Graphics();
+    timerPanel.beginFill(this.panelBg, this.panelBgAlpha);
+    timerPanel.drawRoundedRect(-100, -5, 200, 70, 8);
+    timerPanel.endFill();
+    timerPanel.lineStyle(2, this.neonCyan, 0.4);
+    timerPanel.drawRoundedRect(-100, -5, 200, 70, 8);
+
+    this.raceTimerText.anchor.set(0.5, 0);
+    this.raceTimerText.position.set(0, 0);
+    this.checkpointText.anchor.set(0.5, 0);
+    this.checkpointText.position.set(0, 38);
+
+    this.raceTimerContainer.addChild(timerPanel);
+    this.raceTimerContainer.addChild(this.raceTimerText);
+    this.raceTimerContainer.addChild(this.checkpointText);
+    this.raceTimerContainer.visible = false;
+
+    // Overlay (title/finish screens)
+    this.overlayTitle.anchor.set(0.5, 0.5);
+    this.overlaySubtitle.anchor.set(0.5, 0.5);
+    this.overlayBest.anchor.set(0.5, 0.5);
+
+    this.overlayContainer.addChild(this.overlayBg);
+    this.overlayContainer.addChild(this.overlayTitle);
+    this.overlayContainer.addChild(this.overlaySubtitle);
+    this.overlayContainer.addChild(this.overlayBest);
+    this.overlayContainer.visible = false;
+
+    // Countdown
+    this.countdownText.anchor.set(0.5, 0.5);
+    this.countdownText.visible = false;
+
+    // Sound hint
+    this.soundHintText.alpha = 0.6;
+  }
+
+  updateRace(state: RaceHUDState, dt: number): void {
+    // Sound hint fade
+    if (this.soundHintTimer > 0) {
+      this.soundHintTimer -= dt;
+      this.soundHintText.visible = true;
+      if (this.soundHintTimer < 1) {
+        this.soundHintText.alpha = Math.max(0, this.soundHintTimer) * 0.6;
+      }
+    } else {
+      this.soundHintText.visible = false;
+    }
+
+    // Checkpoint flash effect
+    if (this.flashAlpha > 0) {
+      this.flashAlpha = Math.max(0, this.flashAlpha - dt * 3);
+      this.flashGraphics.clear();
+      this.flashGraphics.beginFill(this.neonCyan, this.flashAlpha * 0.3);
+      this.flashGraphics.drawRect(0, 0, 2000, 2000);
+      this.flashGraphics.endFill();
+      this.flashGraphics.visible = true;
+    } else {
+      this.flashGraphics.visible = false;
+    }
+
+    const showTimer = state.raceState === RaceState.RACING || state.raceState === RaceState.FINISHED;
+    this.raceTimerContainer.visible = showTimer;
+
+    if (showTimer) {
+      this.raceTimerText.text = state.formattedTime;
+      this.checkpointText.text = `Checkpoint ${state.checkpointCurrent}/${state.checkpointTotal}`;
+    }
+
+    // Direction arrow
+    this.arrowGraphics.visible = state.raceState === RaceState.RACING && state.arrowAngle !== null;
+    if (state.arrowAngle !== null && state.raceState === RaceState.RACING) {
+      this.drawDirectionArrow(state.arrowAngle);
+    }
+
+    // Countdown
+    this.countdownText.visible = state.raceState === RaceState.COUNTDOWN;
+    if (state.raceState === RaceState.COUNTDOWN) {
+      this.countdownText.text = state.countdownValue > 0 ? state.countdownValue.toString() : 'GO!';
+    }
+
+    // Overlay screens
+    const showOverlay = state.raceState === RaceState.TITLE
+      || state.raceState === RaceState.READY
+      || state.raceState === RaceState.FINISHED;
+    this.overlayContainer.visible = showOverlay;
+
+    if (showOverlay) {
+      this.drawOverlay(state);
+    }
+  }
+
+  private drawOverlay(state: RaceHUDState): void {
+    this.overlayBg.clear();
+    this.overlayBg.beginFill(0x000000, 0.6);
+    this.overlayBg.drawRect(-1000, -500, 2000, 1000);
+    this.overlayBg.endFill();
+
+    switch (state.raceState) {
+      case RaceState.TITLE:
+        this.overlayTitle.text = 'NEON DESERT OUTLAW';
+        this.overlayTitle.position.set(0, -40);
+        this.overlaySubtitle.text = 'Press ENTER to race';
+        this.overlaySubtitle.position.set(0, 30);
+        if (state.bestTime) {
+          this.overlayBest.text = `Best: ${state.bestTime}`;
+          this.overlayBest.position.set(0, 70);
+          this.overlayBest.visible = true;
+        } else {
+          this.overlayBest.visible = false;
+        }
+        break;
+
+      case RaceState.READY:
+        this.overlayTitle.text = 'READY';
+        this.overlayTitle.position.set(0, -40);
+        this.overlaySubtitle.text = 'Press ENTER to start';
+        this.overlaySubtitle.position.set(0, 30);
+        if (state.bestTime) {
+          this.overlayBest.text = `Best: ${state.bestTime}`;
+          this.overlayBest.position.set(0, 70);
+          this.overlayBest.visible = true;
+        } else {
+          this.overlayBest.visible = false;
+        }
+        break;
+
+      case RaceState.FINISHED:
+        this.overlayTitle.text = state.formattedTime;
+        this.overlayTitle.position.set(0, -40);
+        this.overlaySubtitle.text = 'Press ENTER to restart';
+        this.overlaySubtitle.position.set(0, 30);
+        if (state.bestTime) {
+          this.overlayBest.text = `Best: ${state.bestTime}`;
+          this.overlayBest.position.set(0, 70);
+          this.overlayBest.visible = true;
+        } else {
+          this.overlayBest.visible = false;
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  private drawDirectionArrow(angle: number): void {
+    this.arrowGraphics.clear();
+
+    // Arrow is drawn at a fixed screen position, rotated to point at next checkpoint
+    const size = 16;
+    this.arrowGraphics.beginFill(this.neonMagenta, 0.9);
+    this.arrowGraphics.moveTo(size, 0);
+    this.arrowGraphics.lineTo(-size * 0.5, -size * 0.6);
+    this.arrowGraphics.lineTo(-size * 0.3, 0);
+    this.arrowGraphics.lineTo(-size * 0.5, size * 0.6);
+    this.arrowGraphics.closePath();
+    this.arrowGraphics.endFill();
+
+    this.arrowGraphics.rotation = angle;
+  }
+
+  triggerCheckpointFlash(): void {
+    this.flashAlpha = 1;
+  }
+
   update(state: HUDState): void {
     // Speed in km/h (assuming input is m/s)
     const speedKmh = Math.round(state.speed * 3.6);
@@ -310,5 +592,20 @@ export class HUD {
   setPosition(screenWidth: number, screenHeight: number): void {
     // Drift display at bottom center
     this.driftContainer.position.set(screenWidth / 2, screenHeight - 100);
+
+    // Race timer at top center
+    this.raceTimerContainer.position.set(screenWidth / 2, 15);
+
+    // Direction arrow below timer
+    this.arrowGraphics.position.set(screenWidth / 2, 100);
+
+    // Overlay at center
+    this.overlayContainer.position.set(screenWidth / 2, screenHeight / 2);
+
+    // Countdown at center
+    this.countdownText.position.set(screenWidth / 2, screenHeight / 2);
+
+    // Sound hint at bottom
+    this.soundHintText.position.set(screenWidth / 2 - 70, screenHeight - 30);
   }
 }


### PR DESCRIPTION
## Summary
- **CheckpointManager**: 10-checkpoint neon circuit with pulsing glow effects, bloom, and collection radius detection
- **RaceMode**: State machine (TITLE → READY → COUNTDOWN → RACING → FINISHED) with edge-detected Enter key, input lockout during non-racing states
- **HUD race overlay**: Timer (MM:SS.ms), checkpoint counter, directional arrow to next checkpoint, 3-2-1-GO countdown, title/finish screens, best time display, checkpoint collection flash
- **Best time persistence**: localStorage save/load with graceful fallback
- **Vehicle reset**: Position/velocity/heading reset on race restart

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (all 50 existing tests)
- [x] `npm run build` succeeds
- [ ] Manual play: verify full TITLE → COUNTDOWN → RACING → FINISHED flow
- [ ] Verify checkpoints collect on drive-through with flash effect
- [ ] Verify directional arrow points toward next checkpoint
- [ ] Verify best time saves and displays across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)