### PR TITLE
fix: randomize checkpoints, fix audio, chapter 2 start, and mobile controls

### DIFF
--- a/src/audio/AudioManager.test.ts
+++ b/src/audio/AudioManager.test.ts
@@ -9,19 +9,19 @@ describe('AudioManager', () => {
   });
 
   describe('mute toggle', () => {
-    it('starts muted', () => {
-      expect(audio.muted).toBe(true);
-    });
-
-    it('toggles mute off', () => {
-      audio.toggleMute();
+    it('starts unmuted', () => {
       expect(audio.muted).toBe(false);
     });
 
-    it('toggles mute back on after double toggle', () => {
-      audio.toggleMute();
+    it('toggles mute on', () => {
       audio.toggleMute();
       expect(audio.muted).toBe(true);
+    });
+
+    it('toggles mute back off after double toggle', () => {
+      audio.toggleMute();
+      audio.toggleMute();
+      expect(audio.muted).toBe(false);
     });
   });
 
@@ -48,9 +48,8 @@ describe('AudioManager', () => {
 
   describe('state transitions', () => {
     it('mute state persists through volume changes', () => {
-      // starts muted, unmute first then remute
-      audio.toggleMute(); // unmute
-      audio.toggleMute(); // mute again
+      // starts unmuted, mute then check
+      audio.toggleMute(); // mute
       audio.setVolume(0.9);
       expect(audio.muted).toBe(true);
       expect(audio.volume).toBe(0.9);

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -76,7 +76,7 @@ export class AudioManager {
     },
   ];
 
-  private _muted = true;
+  private _muted = false;
   private _volume = 0.5;
   private started = false;
 

--- a/src/game/CheckpointManager.ts
+++ b/src/game/CheckpointManager.ts
@@ -39,10 +39,19 @@ export class CheckpointManager {
       [-600, 0],      // 9: west on road
       [-200, 200],    // 10: loop back to start area
     ];
-    this.generateFromPositions(waypoints);
+    this.generateFromPositions(waypoints, true);
   }
 
-  generateFromPositions(waypoints: [number, number][]): void {
+  generateFromPositions(waypoints: [number, number][], shuffle = false): void {
+    // Optionally randomize checkpoint order (Fisher-Yates shuffle)
+    if (shuffle) {
+      waypoints = [...waypoints];
+      for (let i = waypoints.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [waypoints[i], waypoints[j]] = [waypoints[j], waypoints[i]];
+      }
+    }
+
     // Clear previous
     this.container.removeChildren();
     this.graphics = [];

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -174,9 +174,11 @@ export class Game {
       this.audio.start();
       window.removeEventListener('click', startAudio);
       window.removeEventListener('keydown', startAudio);
+      window.removeEventListener('touchstart', startAudio);
     };
     window.addEventListener('click', startAudio);
     window.addEventListener('keydown', startAudio);
+    window.addEventListener('touchstart', startAudio);
     this.syncMusicControls();
 
     // Story mode systems
@@ -263,7 +265,6 @@ export class Game {
     this.running = true;
 
     this.missionManager.init(STORY_MISSIONS);
-    this.missionManager.startMission();
 
     // Hide bots in story mode
     for (const bot of this.bots) {
@@ -289,12 +290,17 @@ export class Game {
     this.vehicle.model.yawRate = 0;
     this.driftScore = 0;
     this.accumulator = 0;
-    this.currentSurface = SurfaceType.Road;
+    // For offroad-only missions, start on sand to avoid instant failure
+    if (mission.objectives.type === 'offroad_only') {
+      this.currentSurface = SurfaceType.Sand;
+    } else {
+      this.currentSurface = SurfaceType.Road;
+    }
     this.camera.snapTo(0, 0);
 
     // Setup checkpoints for this mission
     this.checkpoints.reset();
-    this.checkpoints.generateFromPositions(mission.checkpoints);
+    this.checkpoints.generateFromPositions(mission.checkpoints, true);
 
     // Reset race mode to RACING (skip countdown in story)
     this.raceMode.state = RaceState.RACING;

--- a/src/story/Mission.ts
+++ b/src/story/Mission.ts
@@ -133,11 +133,13 @@ export class MissionManager {
     }
 
     if (m.objectives.type === 'offroad_only' && currentSurface === 'Road') {
-      // Small grace: only fail after accumulating road contact
-      this._touchedRoad = true;
-      this._state = 'failed';
-      this._failed = true;
-      return this._state;
+      // Grace period: allow 2 seconds before enforcing offroad rule
+      if (this._missionTime > 2) {
+        this._touchedRoad = true;
+        this._state = 'failed';
+        this._failed = true;
+        return this._state;
+      }
     }
 
     // Check win condition

--- a/src/ui/MainMenu.ts
+++ b/src/ui/MainMenu.ts
@@ -228,6 +228,14 @@ export class MainMenu {
       }),
     });
     text.anchor.set(0.5, 0.5);
+    text.eventMode = 'static';
+    text.cursor = 'pointer';
+    const idx = this.items.length;
+    text.on('pointerdown', () => {
+      this.selectedIndex = idx;
+      this.updateSelection();
+      this.items[idx].action();
+    });
     this.container.addChild(text);
 
     this.items.push({ label, action, text });


### PR DESCRIPTION
## Summary

Addresses all 4 sub-issues from #17.

## Changes

1. **Randomize checkpoints** — Added Fisher-Yates shuffle to `CheckpointManager.generateFromPositions()`. Enabled for both quick race (`generateCircuit`) and story mode.

2. **Fix audio not playing** — Changed `_muted` default from `true` to `false` so audio plays on start. Added `touchstart` event listener for mobile browser autoplay policy compliance.

3. **Chapter 2 story mode instant-fail fix** — The first chapter 2 mission ("Off the Grid") requires offroad-only driving, but `currentSurface` was initialized to `Road`, causing immediate failure. Fixed by:
   - Setting initial surface to `Sand` for offroad missions
   - Adding a 2-second grace period before enforcing the offroad rule
   - Removing duplicate `startMission()` call in `startStory()`

4. **Mobile touch controls** — Made main menu items tappable (added `pointerdown` events) so mobile users can actually start the game. Touch controls for driving were already implemented correctly.

## Testing

- TypeScript compiles clean (`tsc --noEmit`)
- All 52 tests pass (`vitest run`)
- Build succeeds (`vite build`)
- Updated audio tests to match new unmuted default

Fixes the911fund/neon-desert-outlaw#17