### PR TITLE
fix: mobile UX overhaul — responsive layout, touch controls, proper scaling (#21)

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         width: 100%;
         height: 100%;
         overflow: hidden;
+        overscroll-behavior: none;
         background: #0f0b14;
         touch-action: none;
         -webkit-touch-callout: none;

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -23,12 +23,14 @@ import { Headlights } from '../vehicle/Headlights';
 import { AudioManager } from '../audio/AudioManager';
 import { CollisionSystem } from '../physics/CollisionSystem';
 import { Vector2 } from '../utils/Vector2';
+import { DriftPhase } from '../physics/DriftState';
 import { BotVehicle, BOT_COLORS } from '../ai/BotVehicle';
 import { BOT_PERSONALITIES } from '../ai/BotDriver';
 import { MissionManager } from '../story/Mission';
 import type { StoryState } from '../story/Mission';
 import { DialogueBox } from '../story/DialogueBox';
 import { STORY_MISSIONS } from '../story/StoryContent';
+import { getViewportSize } from '../utils/viewport';
 
 export class Game {
   private app: Application;
@@ -99,7 +101,8 @@ export class Game {
 
     // Initialize camera
     this.camera = new Camera();
-    this.camera.setScreenSize(window.innerWidth, window.innerHeight);
+    const initialViewport = getViewportSize();
+    this.camera.setScreenSize(initialViewport.width, initialViewport.height);
     this.camera.snapTo(0, 0);
 
     // Initialize UI components
@@ -107,6 +110,11 @@ export class Game {
     this.miniMap = new MiniMap();
     this.touchControls = new TouchControls({
       onEnter: () => {
+        if (this.dialogue.isVisible) {
+          this.dialogue.advance();
+          return;
+        }
+
         this.raceMode.triggerEnter();
         // Also handle story mode retry/finale on mobile
         if (this.isStoryMode && this.missionManager.state === 'failed') {
@@ -223,6 +231,7 @@ export class Game {
     window.addEventListener('keydown', this.onEscKey);
 
     window.addEventListener('resize', this.handleResize);
+    window.visualViewport?.addEventListener('resize', this.handleResize);
     this.handleResize();
 
     // Initially hidden — call start() to begin gameplay
@@ -288,7 +297,8 @@ export class Game {
     this.setVisible(true);
     this.app.ticker.add(this.update);
     this.handleResize();
-    this.dialogue.resize(window.innerWidth, window.innerHeight);
+    const viewport = getViewportSize();
+    this.dialogue.resize(viewport.width, viewport.height);
 
     this.launchCurrentMission();
   }
@@ -384,16 +394,17 @@ export class Game {
   }
 
   private handleResize = (): void => {
-    this.app.renderer.resize(window.innerWidth, window.innerHeight);
-    this.camera.setScreenSize(window.innerWidth, window.innerHeight);
+    const viewport = getViewportSize();
+    this.app.renderer.resize(viewport.width, viewport.height);
+    this.camera.setScreenSize(viewport.width, viewport.height);
     this.lighting.resize(this.app.renderer.width, this.app.renderer.height);
 
     // Reposition UI elements
-    this.hud.setPosition(window.innerWidth, window.innerHeight);
-    this.miniMap.setPosition(window.innerWidth, window.innerHeight);
-    this.touchControls.setPosition(window.innerWidth, window.innerHeight);
-    this.musicControls.setPosition(window.innerWidth);
-    this.dialogue.resize(window.innerWidth, window.innerHeight);
+    this.hud.setPosition(viewport.width, viewport.height);
+    this.miniMap.setPosition(viewport.width, viewport.height);
+    this.touchControls.setPosition(viewport.width, viewport.height);
+    this.musicControls.setPosition(viewport.width, viewport.height);
+    this.dialogue.resize(viewport.width, viewport.height);
   };
 
   private syncMusicControls(): void {
@@ -511,9 +522,9 @@ export class Game {
       this.accumulator -= GAME_CONFIG.physicsStep;
 
       // Update drift score
-      if (this.vehicle.driftPhase === 'Drifting') {
+      if (this.vehicle.driftPhase === DriftPhase.Drifting) {
         this.driftScore += GAME_CONFIG.physicsStep * this.vehicle.speed * 0.01;
-      } else if (this.vehicle.driftPhase === 'Normal') {
+      } else if (this.vehicle.driftPhase === DriftPhase.Normal) {
         this.driftScore = 0;
       }
     }
@@ -689,6 +700,18 @@ export class Game {
         standings: this.standings.getStandings(),
       }, dt);
     }
+
+    const showMiniMap = this.isStoryMode
+      ? this.missionManager.state === 'playing'
+      : this.raceMode.state === RaceState.RACING;
+    this.miniMap.container.visible = showMiniMap;
+
+    const showEnterButton = this.isStoryMode
+      ? this.missionManager.state === 'failed' || this.missionManager.state === 'finale'
+      : this.raceMode.state === RaceState.TITLE
+        || this.raceMode.state === RaceState.READY
+        || this.raceMode.state === RaceState.FINISHED;
+    this.touchControls.setActionButtonVisibility(true, showEnterButton);
 
     // Story mode updates
     if (this.isStoryMode) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { Application } from 'pixi.js';
 import { Game } from './game/Game';
 import { GameModeManager, GameMode } from './game/GameModeManager';
 import { MainMenu } from './ui/MainMenu';
+import { getViewportSize } from './utils/viewport';
 
 const root = document.getElementById('app');
 if (!root) {
@@ -57,8 +58,13 @@ app
     });
 
     // Initial state: show menu
+    const resizeMenu = (): void => {
+      const viewport = getViewportSize();
+      menu.resize(viewport.width, viewport.height);
+    };
+
     menu.container.visible = true;
-    menu.resize(window.innerWidth, window.innerHeight);
+    resizeMenu();
 
     // Menu update loop
     app.ticker.add(() => {
@@ -69,9 +75,8 @@ app
     });
 
     // Handle resize for menu
-    window.addEventListener('resize', () => {
-      menu.resize(window.innerWidth, window.innerHeight);
-    });
+    window.addEventListener('resize', resizeMenu);
+    window.visualViewport?.addEventListener('resize', resizeMenu);
   })
   .catch((error) => {
     console.error('Failed to initialize Pixi application', error);

--- a/src/story/DialogueBox.ts
+++ b/src/story/DialogueBox.ts
@@ -37,6 +37,9 @@ export class DialogueBox {
     this.container.visible = false;
 
     this.bg = new Graphics();
+    this.bg.eventMode = 'static';
+    this.bg.cursor = 'pointer';
+    this.bg.on('pointertap', () => this.advance());
     this.container.addChild(this.bg);
 
     this.speakerText = new Text({
@@ -123,7 +126,7 @@ export class DialogueBox {
     }
   }
 
-  private advance(): void {
+  advance(): void {
     if (this.finished) return;
 
     if (this.typing) {

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -145,6 +145,9 @@ export class HUD {
     this.countdownText = new Text({ text: '', style: this.createCountdownStyle() });
     this.flashGraphics = new Graphics();
     this.soundHintText = new Text({ text: 'Press M or tap 🔊 for sound', style: this.createLabelStyle() });
+    this.soundHintText.anchor.set(0.5, 0.5);
+    this.soundHintText.style.wordWrap = true;
+    this.soundHintText.style.align = 'center';
 
     // Position display (top right)
     this.positionContainer = new Container();
@@ -170,6 +173,8 @@ export class HUD {
     this.missionTitleText = new Text({ text: '', style: new TextStyle({
       fontFamily: 'monospace', fontSize: 36, fontWeight: 'bold',
       fill: this.neonCyan,
+      wordWrap: true,
+      align: 'center',
       dropShadow: { color: this.neonCyan, blur: 12, distance: 0 },
     })});
     this.missionTitleText.anchor.set(0.5, 0.5);
@@ -177,13 +182,15 @@ export class HUD {
 
     this.chapterTitleText = new Text({ text: '', style: new TextStyle({
       fontFamily: 'monospace', fontSize: 20, fill: this.neonMagenta,
+      wordWrap: true,
+      align: 'center',
       dropShadow: { color: this.neonMagenta, blur: 8, distance: 0 },
     })});
     this.chapterTitleText.anchor.set(0.5, 0.5);
     this.chapterTitleText.visible = false;
 
     this.objectiveText = new Text({ text: '', style: new TextStyle({
-      fontFamily: 'monospace', fontSize: 16, fill: 0xcccccc,
+      fontFamily: 'monospace', fontSize: 16, fill: 0xcccccc, wordWrap: true, align: 'center',
     })});
     this.objectiveText.anchor.set(0.5, 0);
     this.objectiveText.visible = false;
@@ -195,11 +202,13 @@ export class HUD {
     this.storyOverlayTitle = new Text({ text: '', style: new TextStyle({
       fontFamily: 'monospace', fontSize: 48, fontWeight: 'bold',
       fill: this.neonCyan,
+      wordWrap: true,
+      align: 'center',
       dropShadow: { color: this.neonCyan, blur: 16, distance: 0 },
     })});
     this.storyOverlayTitle.anchor.set(0.5, 0.5);
     this.storyOverlaySubtitle = new Text({ text: '', style: new TextStyle({
-      fontFamily: 'monospace', fontSize: 20, fill: 0xcccccc,
+      fontFamily: 'monospace', fontSize: 20, fill: 0xcccccc, wordWrap: true, align: 'center',
     })});
     this.storyOverlaySubtitle.anchor.set(0.5, 0.5);
     this.storyOverlayContainer.addChild(this.storyOverlayBg);
@@ -217,7 +226,7 @@ export class HUD {
     })});
     this.storyFailedTitle.anchor.set(0.5, 0.5);
     this.storyFailedHint = new Text({ text: 'ENTER / ▶ GO to retry  ·  ESC / ✕ BACK for menu', style: new TextStyle({
-      fontFamily: 'monospace', fontSize: 18, fill: 0x999999,
+      fontFamily: 'monospace', fontSize: 18, fill: 0x999999, wordWrap: true, align: 'center',
     })});
     this.storyFailedHint.anchor.set(0.5, 0.5);
     this.storyFailedContainer.addChild(this.storyFailedBg);
@@ -930,73 +939,93 @@ export class HUD {
   }
 
   setPosition(screenWidth: number, screenHeight: number): void {
-    // Responsive scale factor for mobile (reference: 1024px width)
-    const scale = Math.max(0.5, Math.min(1, screenWidth / 1024));
     const isMobile = screenWidth < 768;
+    const compactScale = Math.min(screenWidth / 430, screenHeight / 932);
+    const scale = isMobile ? Math.max(0.72, Math.min(1, compactScale)) : 1;
+    const timerScale = isMobile ? Math.max(0.8, Math.min(1, scale + 0.08)) : 1;
+    const overlayScale = isMobile ? Math.max(0.76, scale) : 1;
+    const padding = isMobile ? 14 : 20;
+    const panelGap = Math.round(10 * scale);
+    const miniMapScale = isMobile ? Math.max(0.68, Math.min(0.92, Math.min(screenWidth / 430, screenHeight / 920))) : 1;
+    const miniMapBottom = padding + 150 * miniMapScale;
+    const speedHeight = 80 * scale;
+    const rpmHeight = 46 * scale;
+    const overlayWrapWidth = (screenWidth * 0.82) / overlayScale;
 
-    // Scale speed panel for mobile
     this.speedContainer.scale.set(scale);
     this.rpmContainer.scale.set(scale);
     this.surfaceContainer.scale.set(scale);
+    this.speedContainer.position.set(padding, padding);
+    this.rpmContainer.position.set(padding, padding + speedHeight + panelGap);
+    this.surfaceContainer.position.set(padding, padding + speedHeight + rpmHeight + panelGap * 2);
 
-    // Drift display at bottom center (higher on mobile to avoid touch controls)
-    const driftY = isMobile ? screenHeight - 180 : screenHeight - 100;
+    const driftY = screenHeight - (isMobile ? Math.max(170, screenHeight * 0.28) : 100);
     this.driftContainer.position.set(screenWidth / 2, driftY);
     this.driftContainer.scale.set(scale);
 
-    // Race timer at top center
-    this.raceTimerContainer.position.set(screenWidth / 2, 15);
-    this.raceTimerContainer.scale.set(scale);
+    this.raceTimerContainer.position.set(screenWidth / 2, padding + 4);
+    this.raceTimerContainer.scale.set(timerScale);
 
-    // Direction arrow below timer
-    this.arrowGraphics.position.set(screenWidth / 2, isMobile ? 80 : 100);
+    this.arrowGraphics.position.set(screenWidth / 2, padding + (isMobile ? 84 : 100) * timerScale);
 
-    // Overlay at center
     this.overlayContainer.position.set(screenWidth / 2, screenHeight / 2);
-    this.overlayContainer.scale.set(scale);
+    this.overlayContainer.scale.set(overlayScale);
+    this.overlayTitle.style.wordWrap = true;
+    this.overlayTitle.style.wordWrapWidth = overlayWrapWidth;
+    this.overlayTitle.style.align = 'center';
+    this.overlaySubtitle.style.wordWrap = true;
+    this.overlaySubtitle.style.wordWrapWidth = overlayWrapWidth;
+    this.overlaySubtitle.style.align = 'center';
+    this.overlayBest.style.wordWrap = true;
+    this.overlayBest.style.wordWrapWidth = overlayWrapWidth;
+    this.overlayBest.style.align = 'center';
 
-    // Countdown at center
     this.countdownText.position.set(screenWidth / 2, screenHeight / 2);
-    this.countdownText.scale.set(scale);
+    this.countdownText.scale.set(overlayScale);
 
-    // Sound hint at bottom
-    this.soundHintText.position.set(screenWidth / 2 - 70 * scale, screenHeight - 30);
+    this.soundHintText.style.wordWrapWidth = screenWidth * 0.55;
+    this.soundHintText.position.set(screenWidth / 2, screenHeight - (isMobile ? 140 : 28));
     this.soundHintText.scale.set(scale);
 
-    // Position display (top right, left of minimap — closer on mobile)
-    const posX = isMobile ? screenWidth - 180 : screenWidth - 280;
-    this.positionContainer.position.set(posX, 20);
+    const positionY = isMobile ? miniMapBottom + 12 : padding;
+    this.positionContainer.position.set(screenWidth - padding - 90 * scale, positionY);
     this.positionContainer.scale.set(scale);
 
-    // Standings below position
-    this.standingsContainer.position.set(posX, 20 + 70 * scale);
+    this.standingsContainer.position.set(
+      screenWidth - padding - 140 * scale,
+      positionY + 70 * scale
+    );
     this.standingsContainer.scale.set(scale);
 
-    // Story HUD positions
-    this.missionTitleText.position.set(screenWidth / 2, screenHeight / 2);
+    this.missionTitleText.style.wordWrapWidth = (screenWidth * 0.82) / scale;
+    this.missionTitleText.position.set(screenWidth / 2, screenHeight * (isMobile ? 0.44 : 0.5));
     this.missionTitleText.scale.set(scale);
-    this.chapterTitleText.position.set(screenWidth / 2, screenHeight / 2 - 50 * scale);
+    this.chapterTitleText.style.wordWrapWidth = (screenWidth * 0.82) / scale;
+    this.chapterTitleText.position.set(screenWidth / 2, this.missionTitleText.y - 52 * scale);
     this.chapterTitleText.scale.set(scale);
-    this.objectiveText.position.set(screenWidth / 2, isMobile ? 70 : 90);
+    this.objectiveText.style.wordWrapWidth = (screenWidth * 0.68) / scale;
+    this.objectiveText.position.set(screenWidth / 2, padding + (isMobile ? 86 : 94) * timerScale);
     this.objectiveText.scale.set(scale);
 
-    // Story overlays
     this.storyOverlayBg.clear();
     this.storyOverlayBg.beginFill(0x000000, 0.7);
     this.storyOverlayBg.drawRect(0, 0, screenWidth, screenHeight);
     this.storyOverlayBg.endFill();
-    this.storyOverlayTitle.position.set(screenWidth / 2, screenHeight / 2 - 30);
-    this.storyOverlayTitle.scale.set(scale);
-    this.storyOverlaySubtitle.position.set(screenWidth / 2, screenHeight / 2 + 50);
+    this.storyOverlayTitle.style.wordWrapWidth = (screenWidth * 0.86) / overlayScale;
+    this.storyOverlayTitle.position.set(screenWidth / 2, screenHeight / 2 - 32 * overlayScale);
+    this.storyOverlayTitle.scale.set(overlayScale);
+    this.storyOverlaySubtitle.style.wordWrapWidth = (screenWidth * 0.8) / overlayScale;
+    this.storyOverlaySubtitle.position.set(screenWidth / 2, screenHeight / 2 + 52 * overlayScale);
     this.storyOverlaySubtitle.scale.set(scale);
 
     this.storyFailedBg.clear();
     this.storyFailedBg.beginFill(0x000000, 0.7);
     this.storyFailedBg.drawRect(0, 0, screenWidth, screenHeight);
     this.storyFailedBg.endFill();
-    this.storyFailedTitle.position.set(screenWidth / 2, screenHeight / 2 - 20);
-    this.storyFailedTitle.scale.set(scale);
-    this.storyFailedHint.position.set(screenWidth / 2, screenHeight / 2 + 40);
+    this.storyFailedTitle.position.set(screenWidth / 2, screenHeight / 2 - 24 * overlayScale);
+    this.storyFailedTitle.scale.set(overlayScale);
+    this.storyFailedHint.style.wordWrapWidth = (screenWidth * 0.8) / scale;
+    this.storyFailedHint.position.set(screenWidth / 2, screenHeight / 2 + 44 * scale);
     this.storyFailedHint.scale.set(scale);
   }
 }

--- a/src/ui/MainMenu.ts
+++ b/src/ui/MainMenu.ts
@@ -9,6 +9,8 @@ export interface MainMenuCallbacks {
 interface MenuItem {
   label: string;
   action: () => void;
+  container: Container;
+  background: Graphics;
   text: Text;
 }
 
@@ -35,26 +37,27 @@ export class MainMenu {
   private selectedIndex = 0;
   private pulseTime = 0;
 
-  // "Coming Soon" toast
   private toastText: Text;
   private toastTimer = 0;
 
-  // Controls overlay
   private controlsContainer: Container;
   private controlsBg: Graphics;
+  private controlsCard: Graphics;
   private controlsTitle: Text;
   private controlsBody: Text;
+  private controlsHintButton: Container;
+  private controlsHintBg: Graphics;
   private controlsHint: Text;
 
-  // Animated particles
   private particleGraphics: Graphics;
   private particles: Particle[] = [];
 
   private callbacks: MainMenuCallbacks;
   private screenWidth = 0;
   private screenHeight = 0;
+  private buttonWidth = 320;
+  private buttonHeight = 64;
 
-  // Keyboard state
   private onKeyDown: (e: KeyboardEvent) => void;
   private showingControls = false;
 
@@ -62,15 +65,12 @@ export class MainMenu {
     this.callbacks = callbacks;
     this.container = new Container();
 
-    // Background
     this.bg = new Graphics();
     this.container.addChild(this.bg);
 
-    // Particle layer
     this.particleGraphics = new Graphics();
     this.container.addChild(this.particleGraphics);
 
-    // Title
     this.titleText = new Text({
       text: 'NEON DESERT OUTLAW',
       style: new TextStyle({
@@ -78,6 +78,7 @@ export class MainMenu {
         fontSize: 64,
         fontWeight: 'bold',
         fill: NEON_CYAN,
+        align: 'center',
         dropShadow: {
           color: NEON_CYAN,
           blur: 24,
@@ -88,24 +89,22 @@ export class MainMenu {
     this.titleText.anchor.set(0.5, 0.5);
     this.container.addChild(this.titleText);
 
-    // Subtitle
     this.subtitleText = new Text({
       text: 'A Desert Racing Game',
       style: new TextStyle({
         fontFamily: 'monospace',
         fontSize: 20,
         fill: 0x888888,
+        align: 'center',
       }),
     });
     this.subtitleText.anchor.set(0.5, 0.5);
     this.container.addChild(this.subtitleText);
 
-    // Menu items
     this.createMenuItem('QUICK RACE', () => this.callbacks.onQuickRace());
     this.createMenuItem('STORY MODE', () => this.handleStoryMode());
     this.createMenuItem('CONTROLS', () => this.callbacks.onControls());
 
-    // Toast text for "Coming Soon"
     this.toastText = new Text({
       text: 'Coming Soon...',
       style: new TextStyle({
@@ -124,12 +123,12 @@ export class MainMenu {
     this.toastText.visible = false;
     this.container.addChild(this.toastText);
 
-    // Controls overlay (rendered within the menu container)
     this.controlsContainer = new Container();
     this.controlsContainer.visible = false;
 
     this.controlsBg = new Graphics();
-    this.controlsContainer.addChild(this.controlsBg);
+    this.controlsCard = new Graphics();
+    this.controlsContainer.addChild(this.controlsBg, this.controlsCard);
 
     this.controlsTitle = new Text({
       text: 'CONTROLS',
@@ -150,50 +149,55 @@ export class MainMenu {
 
     this.controlsBody = new Text({
       text: [
-        '--- KEYBOARD ---',
-        'WASD / Arrow Keys .... Drive',
-        'Space ................ Handbrake',
-        'M .................... Toggle Sound',
-        'Enter ................ Start Race',
-        'ESC .................. Back to Menu',
+        'KEYBOARD',
+        'WASD / Arrows  Drive',
+        'Space          Handbrake',
+        'M              Toggle Sound',
+        'Enter          Start / Confirm',
+        'Esc            Back to Menu',
         '',
-        '--- MOBILE / TOUCH ---',
-        'Left Joystick ........ Steer & Throttle',
-        'B Button ............. Brake',
-        'H Button ............. Handbrake',
-        '▶ GO Button .......... Start Race',
-        '✕ BACK Button ........ Back to Menu',
+        'TOUCH',
+        'Left Pad       Steer + Throttle',
+        'Brake          Slow / Reverse',
+        'Drift          Handbrake slide',
+        'Back           Return to Menu',
+        'Go             Start / Retry',
       ].join('\n'),
       style: new TextStyle({
         fontFamily: 'monospace',
         fontSize: 20,
         fill: 0xcccccc,
         lineHeight: 34,
+        align: 'center',
+        wordWrap: true,
+        wordWrapWidth: 460,
       }),
     });
-    this.controlsBody.anchor.set(0.5, 0.5);
+    this.controlsBody.anchor.set(0.5, 0);
     this.controlsContainer.addChild(this.controlsBody);
 
+    this.controlsHintButton = new Container();
+    this.controlsHintBg = new Graphics();
     this.controlsHint = new Text({
-      text: 'Press ESC / ENTER or tap here to go back',
+      text: 'BACK',
       style: new TextStyle({
         fontFamily: 'monospace',
         fontSize: 16,
-        fill: DIM_CYAN,
+        fontWeight: 'bold',
+        fill: NEON_CYAN,
       }),
     });
     this.controlsHint.anchor.set(0.5, 0.5);
-    this.controlsHint.eventMode = 'static';
-    this.controlsHint.cursor = 'pointer';
-    this.controlsHint.on('pointerdown', () => this.hideControls());
-    this.controlsContainer.addChild(this.controlsHint);
+    this.controlsHintButton.addChild(this.controlsHintBg, this.controlsHint);
+    this.controlsHintBg.eventMode = 'static';
+    this.controlsHintBg.cursor = 'pointer';
+    this.controlsHintBg.on('pointertap', () => this.hideControls());
+    this.controlsContainer.addChild(this.controlsHintButton);
 
     this.container.addChild(this.controlsContainer);
 
-    // Init particles
     this.initParticles();
 
-    // Keyboard listener
     this.onKeyDown = (e: KeyboardEvent): void => {
       if (!this.container.visible) return;
 
@@ -204,7 +208,6 @@ export class MainMenu {
         return;
       }
 
-      // Toast is showing — ignore input
       if (this.toastTimer > 0) return;
 
       switch (e.code) {
@@ -219,7 +222,7 @@ export class MainMenu {
           this.updateSelection();
           break;
         case 'Enter':
-          this.items[this.selectedIndex].action();
+          this.items[this.selectedIndex]?.action();
           break;
       }
     };
@@ -228,7 +231,13 @@ export class MainMenu {
     this.updateSelection();
   }
 
+  private clamp(value: number, min: number, max: number): number {
+    return Math.max(min, Math.min(max, value));
+  }
+
   private createMenuItem(label: string, action: () => void): void {
+    const container = new Container();
+    const background = new Graphics();
     const text = new Text({
       text: label,
       style: new TextStyle({
@@ -239,17 +248,46 @@ export class MainMenu {
       }),
     });
     text.anchor.set(0.5, 0.5);
-    text.eventMode = 'static';
-    text.cursor = 'pointer';
+
+    background.eventMode = 'static';
+    background.cursor = 'pointer';
+
     const idx = this.items.length;
-    text.on('pointerdown', () => {
+    background.on('pointertap', () => {
       this.selectedIndex = idx;
       this.updateSelection();
-      this.items[idx].action();
+      this.items[idx]?.action();
     });
-    this.container.addChild(text);
 
-    this.items.push({ label, action, text });
+    container.addChild(background, text);
+    this.container.addChild(container);
+    this.items.push({ label, action, container, background, text });
+  }
+
+  private drawMenuButton(item: MenuItem, selected: boolean): void {
+    item.background.clear();
+    item.background.beginFill(0x08151b, selected ? 0.9 : 0.76);
+    item.background.drawRoundedRect(
+      -this.buttonWidth / 2,
+      -this.buttonHeight / 2,
+      this.buttonWidth,
+      this.buttonHeight,
+      14
+    );
+    item.background.endFill();
+    item.background.lineStyle(2, selected ? NEON_MAGENTA : NEON_CYAN, selected ? 0.9 : 0.38);
+    item.background.drawRoundedRect(
+      -this.buttonWidth / 2,
+      -this.buttonHeight / 2,
+      this.buttonWidth,
+      this.buttonHeight,
+      14
+    );
+
+    item.text.style.fill = selected ? NEON_MAGENTA : 0xd8fafa;
+    item.text.style.dropShadow = selected
+      ? { color: NEON_MAGENTA, blur: 12, distance: 0, alpha: 1, angle: 0 }
+      : false;
   }
 
   private handleStoryMode(): void {
@@ -259,11 +297,10 @@ export class MainMenu {
   showControls(): void {
     this.showingControls = true;
     this.controlsContainer.visible = true;
-    // Hide menu items behind controls
     this.titleText.visible = false;
     this.subtitleText.visible = false;
     for (const item of this.items) {
-      item.text.visible = false;
+      item.container.visible = false;
     }
     this.toastText.visible = false;
     this.layoutControls();
@@ -275,22 +312,51 @@ export class MainMenu {
     this.titleText.visible = true;
     this.subtitleText.visible = true;
     for (const item of this.items) {
-      item.text.visible = true;
+      item.container.visible = true;
     }
   }
 
   private layoutControls(): void {
-    const cx = this.screenWidth / 2;
-    const cy = this.screenHeight / 2;
+    const isPhone = this.screenWidth < 560;
+    const cardWidth = Math.min(this.screenWidth - 24, isPhone ? 420 : 560);
+    const cardHeight = Math.min(this.screenHeight - 24, isPhone ? 560 : 620);
+    const cardX = (this.screenWidth - cardWidth) / 2;
+    const cardY = (this.screenHeight - cardHeight) / 2;
+    const titleSize = isPhone ? 32 : 48;
+    const bodySize = isPhone ? 14 : 20;
+    const lineHeight = isPhone ? 22 : 34;
+    const hintWidth = Math.min(cardWidth - 36, 180);
+    const hintHeight = 48;
 
     this.controlsBg.clear();
-    this.controlsBg.beginFill(BG_COLOR, 0.95);
+    this.controlsBg.beginFill(BG_COLOR, 0.96);
     this.controlsBg.drawRect(0, 0, this.screenWidth, this.screenHeight);
     this.controlsBg.endFill();
 
-    this.controlsTitle.position.set(cx, cy - 160);
-    this.controlsBody.position.set(cx, cy + 10);
-    this.controlsHint.position.set(cx, cy + 180);
+    this.controlsCard.clear();
+    this.controlsCard.beginFill(0x08151b, 0.94);
+    this.controlsCard.drawRoundedRect(cardX, cardY, cardWidth, cardHeight, 18);
+    this.controlsCard.endFill();
+    this.controlsCard.lineStyle(2, NEON_CYAN, 0.55);
+    this.controlsCard.drawRoundedRect(cardX, cardY, cardWidth, cardHeight, 18);
+
+    this.controlsTitle.style.fontSize = titleSize;
+    this.controlsTitle.position.set(this.screenWidth / 2, cardY + 52);
+
+    this.controlsBody.style.fontSize = bodySize;
+    this.controlsBody.style.lineHeight = lineHeight;
+    this.controlsBody.style.wordWrapWidth = cardWidth - 40;
+    this.controlsBody.position.set(this.screenWidth / 2, cardY + 96);
+
+    this.controlsHintBg.clear();
+    this.controlsHintBg.beginFill(0x08151b, 1);
+    this.controlsHintBg.drawRoundedRect(-hintWidth / 2, -hintHeight / 2, hintWidth, hintHeight, 12);
+    this.controlsHintBg.endFill();
+    this.controlsHintBg.lineStyle(2, NEON_CYAN, 0.6);
+    this.controlsHintBg.drawRoundedRect(-hintWidth / 2, -hintHeight / 2, hintWidth, hintHeight, 12);
+
+    this.controlsHint.style.fontSize = isPhone ? 15 : 16;
+    this.controlsHintButton.position.set(this.screenWidth / 2, cardY + cardHeight - 42);
   }
 
   private initParticles(): void {
@@ -308,11 +374,7 @@ export class MainMenu {
   private updateSelection(): void {
     for (let i = 0; i < this.items.length; i++) {
       const item = this.items[i];
-      const selected = i === this.selectedIndex;
-      item.text.style.fill = selected ? NEON_MAGENTA : DIM_CYAN;
-      item.text.style.dropShadow = selected
-        ? { color: NEON_MAGENTA, blur: 12, distance: 0, alpha: 1, angle: 0 }
-        : false;
+      this.drawMenuButton(item, i === this.selectedIndex);
     }
   }
 
@@ -320,42 +382,39 @@ export class MainMenu {
     this.screenWidth = width;
     this.screenHeight = height;
 
-    // Draw background
     this.bg.clear();
     this.bg.beginFill(BG_COLOR);
     this.bg.drawRect(0, 0, width, height);
     this.bg.endFill();
 
     const cx = width / 2;
+    const isPhone = width < 560;
+    const titleSize = isPhone
+      ? Math.round(this.clamp(width * 0.11, 34, 44))
+      : Math.round(this.clamp(width * 0.065, 48, 64));
+    const subtitleSize = isPhone ? 16 : Math.round(this.clamp(width * 0.022, 18, 20));
 
-    // Responsive scale factor for mobile (reference: 1024px width)
-    const scale = Math.min(1, width / 1024);
-    const mobileScale = Math.max(0.5, scale);
+    this.titleText.text = isPhone ? 'NEON DESERT\nOUTLAW' : 'NEON DESERT OUTLAW';
+    this.titleText.style.fontSize = titleSize;
+    this.subtitleText.style.fontSize = subtitleSize;
 
-    // Scale title for mobile
-    this.titleText.style.fontSize = Math.round(64 * mobileScale);
-    this.subtitleText.style.fontSize = Math.round(20 * mobileScale);
+    this.titleText.position.set(cx, isPhone ? height * 0.18 : height * 0.22);
+    this.subtitleText.position.set(cx, this.titleText.y + (isPhone ? 52 : 58));
 
-    // Scale menu items
-    for (const item of this.items) {
-      item.text.style.fontSize = Math.round(28 * mobileScale);
-    }
+    this.buttonWidth = Math.min(width - 32, isPhone ? 320 : 360);
+    this.buttonHeight = isPhone ? 58 : 64;
+    const itemSpacing = this.buttonHeight + (isPhone ? 14 : 18);
+    const menuStartY = isPhone ? height * 0.44 : height * 0.5;
 
-    // Title position
-    this.titleText.position.set(cx, height * 0.22);
-    const subtitleGap = 55 * mobileScale;
-    this.subtitleText.position.set(cx, height * 0.22 + subtitleGap);
-
-    // Menu items
-    const menuStartY = height * 0.50;
-    const itemSpacing = Math.round(55 * mobileScale);
     for (let i = 0; i < this.items.length; i++) {
-      this.items[i].text.position.set(cx, menuStartY + i * itemSpacing);
+      const item = this.items[i];
+      item.text.style.fontSize = isPhone ? 22 : 28;
+      item.container.position.set(cx, menuStartY + i * itemSpacing);
     }
+    this.updateSelection();
 
-    // Toast
-    this.toastText.style.fontSize = Math.round(24 * mobileScale);
-    this.toastText.position.set(cx, menuStartY + this.items.length * itemSpacing + 40);
+    this.toastText.style.fontSize = isPhone ? 20 : 24;
+    this.toastText.position.set(cx, menuStartY + this.items.length * itemSpacing + 28);
 
     if (this.showingControls) {
       this.layoutControls();
@@ -365,21 +424,18 @@ export class MainMenu {
   update(dt: number): void {
     this.pulseTime += dt;
 
-    // Pulse animation on selected item
     const selectedItem = this.items[this.selectedIndex];
     if (selectedItem) {
-      const scale = 1 + Math.sin(this.pulseTime * 4) * 0.04;
-      selectedItem.text.scale.set(scale, scale);
+      const scale = 1 + Math.sin(this.pulseTime * 4) * 0.03;
+      selectedItem.container.scale.set(scale, scale);
     }
 
-    // Reset non-selected items scale
     for (let i = 0; i < this.items.length; i++) {
       if (i !== this.selectedIndex) {
-        this.items[i].text.scale.set(1, 1);
+        this.items[i].container.scale.set(1, 1);
       }
     }
 
-    // Toast timer
     if (this.toastTimer > 0) {
       this.toastTimer -= dt;
       if (this.toastTimer <= 0.5) {
@@ -391,19 +447,20 @@ export class MainMenu {
       }
     }
 
-    // Animate particles
     this.particleGraphics.clear();
     for (const p of this.particles) {
       p.x += p.vx * dt;
       p.y += p.vy * dt;
 
-      // Wrap around screen
       if (p.x < 0) p.x = this.screenWidth;
       if (p.x > this.screenWidth) p.x = 0;
       if (p.y < 0) p.y = this.screenHeight;
       if (p.y > this.screenHeight) p.y = 0;
 
-      this.particleGraphics.beginFill(NEON_CYAN, p.alpha * (0.5 + 0.5 * Math.sin(this.pulseTime * 2 + p.x * 0.01)));
+      this.particleGraphics.beginFill(
+        NEON_CYAN,
+        p.alpha * (0.5 + 0.5 * Math.sin(this.pulseTime * 2 + p.x * 0.01))
+      );
       this.particleGraphics.drawCircle(p.x, p.y, 1.5);
       this.particleGraphics.endFill();
     }

--- a/src/ui/MiniMap.ts
+++ b/src/ui/MiniMap.ts
@@ -1,5 +1,6 @@
 import { Container, Graphics } from 'pixi.js';
-import { SurfaceType, SurfaceColors } from '../physics/SurfaceTypes';
+import { SurfaceColors } from '../physics/SurfaceTypes';
+import type { SurfaceType } from '../physics/SurfaceTypes';
 
 export interface MiniMapChunk {
   x: number;
@@ -133,8 +134,6 @@ export class MiniMap {
   private drawTerrain(state: MiniMapState): void {
     this.terrain.clear();
 
-    const centerX = this.size / 2;
-    const centerY = this.size / 2;
     const viewRadius = this.size / 2 / this.scale;
 
     // Draw simplified terrain based on surface grid
@@ -252,12 +251,14 @@ export class MiniMap {
   }
 
   setPosition(screenWidth: number, screenHeight: number): void {
-    // Scale down on mobile screens
-    const scale = screenWidth < 768 ? 0.65 : 1;
+    const compactScale = Math.min(screenWidth / 430, screenHeight / 920);
+    const scale = screenWidth < 768
+      ? Math.max(0.68, Math.min(0.92, compactScale))
+      : 1;
     this.container.scale.set(scale);
 
-    // Position in top-right corner with padding
     const effectiveSize = this.size * scale;
-    this.container.position.set(screenWidth - effectiveSize - 16, 16);
+    const padding = screenWidth < 768 ? 14 : 16;
+    this.container.position.set(screenWidth - effectiveSize - padding, padding);
   }
 }

--- a/src/ui/MusicControls.ts
+++ b/src/ui/MusicControls.ts
@@ -5,10 +5,10 @@ export interface MusicControlsState {
   isPlaying: boolean;
 }
 
-interface ButtonDef {
-  label: string;
-  x: number;
-  width: number;
+interface ControlButton {
+  container: Container;
+  background: Graphics;
+  label: Text;
   onTap: () => void;
 }
 
@@ -19,9 +19,11 @@ export class MusicControls {
   private titleText: Text;
   private trackText: Text;
   private playPauseText: Text;
-  private readonly buttons: Graphics[] = [];
+  private readonly buttons: ControlButton[] = [];
   private width = 300;
   private height = 88;
+  private buttonHeight = 30;
+  private compactMode = false;
 
   constructor(onPrev: () => void, onPlayPause: () => void, onNext: () => void) {
     this.container = new Container();
@@ -54,61 +56,104 @@ export class MusicControls {
 
     this.container.addChild(this.panel, this.titleText, this.trackText, this.playPauseText);
 
-    const defs: ButtonDef[] = [
-      { label: '<', x: 16, width: 26, onTap: onPrev },
-      { label: '|| / >', x: 50, width: 62, onTap: onPlayPause },
-      { label: '>', x: 120, width: 26, onTap: onNext },
+    const defs = [
+      { label: '<', onTap: onPrev },
+      { label: 'PLAY / PAUSE', onTap: onPlayPause },
+      { label: '>', onTap: onNext },
     ];
 
     for (const def of defs) {
-      this.buttons.push(this.createButton(def));
+      this.buttons.push(this.createButton(def.label, def.onTap));
     }
 
     this.layout();
   }
 
-  private createButton(def: ButtonDef): Graphics {
-    const g = new Graphics();
-    g.roundRect(0, 0, def.width, 24, 6);
-    g.fill({ color: 0x112233, alpha: 0.92 });
-    g.stroke({ color: 0x00ffff, width: 1, alpha: 0.8 });
-    g.position.set(def.x, 52);
-    g.eventMode = 'static';
-    g.cursor = 'pointer';
-    g.on('pointertap', def.onTap);
-
-    const label = new Text({
-      text: def.label,
+  private createButton(label: string, onTap: () => void): ControlButton {
+    const container = new Container();
+    const background = new Graphics();
+    const text = new Text({
+      text: label,
       style: new TextStyle({
         fontFamily: 'monospace',
-        fontSize: 11,
+        fontSize: 12,
+        fontWeight: 'bold',
         fill: 0x00ffff,
       }),
     });
-    label.anchor.set(0.5, 0.5);
-    label.position.set(def.width / 2, 12);
-    g.addChild(label);
+    text.anchor.set(0.5, 0.5);
 
-    this.container.addChild(g);
-    return g;
+    background.eventMode = 'static';
+    background.cursor = 'pointer';
+    background.on('pointertap', onTap);
+
+    container.addChild(background, text);
+    this.container.addChild(container);
+
+    return { container, background, label: text, onTap };
+  }
+
+  private drawButton(button: ControlButton, x: number, y: number, width: number): void {
+    button.container.position.set(x, y);
+    button.background.clear();
+    button.background.beginFill(0x112233, 0.94);
+    button.background.drawRoundedRect(0, 0, width, this.buttonHeight, 10);
+    button.background.endFill();
+    button.background.lineStyle(2, 0x00ffff, 0.75);
+    button.background.drawRoundedRect(0, 0, width, this.buttonHeight, 10);
+    button.label.style.fontSize = this.compactMode ? 12 : 11;
+    button.label.position.set(width / 2, this.buttonHeight / 2);
   }
 
   private layout(): void {
     this.panel.clear();
-    this.panel.roundRect(0, 0, this.width, this.height, 8);
-    this.panel.fill({ color: 0x090d18, alpha: 0.85 });
-    this.panel.stroke({ color: 0x00ffff, width: 1, alpha: 0.6 });
+    this.panel.beginFill(0x090d18, 0.88);
+    this.panel.drawRoundedRect(0, 0, this.width, this.height, 10);
+    this.panel.endFill();
+    this.panel.lineStyle(1.5, 0x00ffff, 0.6);
+    this.panel.drawRoundedRect(0, 0, this.width, this.height, 10);
 
-    this.titleText.position.set(16, 8);
-    this.trackText.position.set(16, 26);
-    this.playPauseText.position.set(164, 58);
+    this.titleText.style.fontSize = this.compactMode ? 13 : 12;
+    this.trackText.style.fontSize = this.compactMode ? 14 : 13;
+    this.playPauseText.style.fontSize = this.compactMode ? 12 : 11;
+    this.trackText.style.wordWrap = true;
+    this.trackText.style.wordWrapWidth = this.width - 24;
+
+    this.titleText.position.set(14, 8);
+    this.trackText.position.set(14, 26);
+    this.playPauseText.position.set(14, this.compactMode ? 48 : 58);
+
+    if (this.compactMode) {
+      this.drawButton(this.buttons[0], 14, 68, 48);
+      this.drawButton(this.buttons[1], 70, 68, 100);
+      this.drawButton(this.buttons[2], 178, 68, 48);
+    } else {
+      this.drawButton(this.buttons[0], 16, 52, 36);
+      this.drawButton(this.buttons[1], 60, 52, 112);
+      this.drawButton(this.buttons[2], 180, 52, 36);
+    }
   }
 
-  setPosition(screenWidth: number): void {
-    // Scale down on mobile
-    const scale = screenWidth < 768 ? 0.7 : 1;
-    this.container.scale.set(scale);
-    this.container.position.set(screenWidth - this.width * scale - 12, 12);
+  setPosition(screenWidth: number, screenHeight: number): void {
+    this.compactMode = screenWidth < 768;
+
+    if (this.compactMode) {
+      this.width = Math.min(240, screenWidth - 32);
+      this.height = 118;
+      this.buttonHeight = 44;
+      this.layout();
+      this.container.position.set(14, Math.round(18 + 208 * Math.min(screenWidth / 430, 1)));
+    } else {
+      this.width = 300;
+      this.height = 88;
+      this.buttonHeight = 30;
+      this.layout();
+      this.container.position.set(screenWidth - this.width - 12, 12);
+    }
+
+    if (this.compactMode && this.container.y + this.height > screenHeight - 220) {
+      this.container.y = Math.max(14, screenHeight - this.height - 220);
+    }
   }
 
   setState(state: MusicControlsState): void {

--- a/src/ui/TouchControls.ts
+++ b/src/ui/TouchControls.ts
@@ -1,4 +1,12 @@
-import { Container, Graphics, Text, TextStyle, FederatedPointerEvent } from 'pixi.js';
+import {
+  Circle,
+  Container,
+  Graphics,
+  RoundedRectangle,
+  Text,
+  TextStyle,
+} from 'pixi.js';
+import type { FederatedPointerEvent } from 'pixi.js';
 import { clamp } from '../utils/MathUtils';
 
 export interface TouchInput {
@@ -13,69 +21,100 @@ export interface TouchActionCallbacks {
   onBack?: () => void;
 }
 
+interface ActionButtonRefs {
+  container: Container;
+  background: Graphics;
+  label: Text;
+}
+
+interface ControlButtonRefs {
+  container: Container;
+  background: Graphics;
+  label: Text;
+}
+
 export class TouchControls {
   readonly container: Container;
 
   private joystickContainer: Container;
   private joystickBase: Graphics;
   private joystickKnob: Graphics;
+  private joystickHint: Text;
 
-  private brakeButton: Graphics;
-  private handbrakeButton: Graphics;
+  private brakeButton: ControlButtonRefs;
+  private handbrakeButton: ControlButtonRefs;
 
-  // Action buttons for mobile navigation
-  private backButton: Container;
-  private enterButton: Container;
+  private backButton: ActionButtonRefs;
+  private enterButton: ActionButtonRefs;
 
-  private readonly joystickRadius = 60;
-  private readonly knobRadius = 25;
-  private readonly buttonRadius = 40;
-  private readonly actionButtonWidth = 70;
-  private readonly actionButtonHeight = 36;
+  private joystickBaseRadius = 70;
+  private joystickKnobRadius = 30;
+  private buttonRadius = 46;
+  private actionButtonWidth = 100;
+  private actionButtonHeight = 48;
+  private controlPadding = 18;
+  private bottomPadding = 24;
+  private screenWidth = 0;
+  private screenHeight = 0;
+  private joystickCenter = { x: 0, y: 0 };
+
   private readonly neonCyan = 0x00ffff;
   private readonly neonMagenta = 0xff00ff;
   private readonly neonRed = 0xff4444;
   private readonly neonGreen = 0x44ff44;
 
-  private joystickActive = false;
   private joystickTouchId: number | null = null;
   private joystickOffset = { x: 0, y: 0 };
-
-  private brakeActive = false;
-  private handbrakeActive = false;
+  private brakeTouchId: number | null = null;
+  private handbrakeTouchId: number | null = null;
 
   private isTouchDevice = false;
   private _visible = false;
+  private backButtonVisible = true;
+  private enterButtonVisible = true;
   private callbacks: TouchActionCallbacks = {};
 
   constructor(callbacks?: TouchActionCallbacks) {
     this.container = new Container();
     if (callbacks) this.callbacks = callbacks;
 
-    // Detect touch capability
     this.isTouchDevice = this.detectTouchDevice();
 
     this.joystickContainer = new Container();
     this.joystickBase = new Graphics();
     this.joystickKnob = new Graphics();
+    this.joystickHint = new Text({
+      text: 'STEER / GAS',
+      style: new TextStyle({
+        fontFamily: 'monospace',
+        fontSize: 14,
+        fontWeight: 'bold',
+        fill: this.neonCyan,
+      }),
+    });
+    this.joystickHint.anchor.set(0.5, 0.5);
 
-    this.brakeButton = new Graphics();
-    this.handbrakeButton = new Graphics();
+    this.brakeButton = this.createControlButton('BRAKE', this.neonRed);
+    this.handbrakeButton = this.createControlButton('DRIFT', this.neonMagenta);
 
-    // Action buttons
-    this.backButton = this.createActionButton('✕ BACK', this.neonRed, () => this.callbacks.onBack?.());
-    this.enterButton = this.createActionButton('▶ GO', this.neonGreen, () => this.callbacks.onEnter?.());
+    this.backButton = this.createActionButton('BACK', this.neonRed, () => this.callbacks.onBack?.());
+    this.enterButton = this.createActionButton('GO', this.neonGreen, () => this.callbacks.onEnter?.());
 
-    this.setupJoystick();
-    this.setupButtons();
+    this.joystickContainer.addChild(this.joystickBase, this.joystickKnob, this.joystickHint);
+    this.container.addChild(
+      this.joystickContainer,
+      this.brakeButton.container,
+      this.handbrakeButton.container,
+      this.backButton.container,
+      this.enterButton.container
+    );
 
-    this.container.addChild(this.joystickContainer);
-    this.container.addChild(this.brakeButton);
-    this.container.addChild(this.handbrakeButton);
-    this.container.addChild(this.backButton);
-    this.container.addChild(this.enterButton);
+    this.redrawJoystick();
+    this.redrawControlButton(this.brakeButton, this.neonRed, false);
+    this.redrawControlButton(this.handbrakeButton, this.neonMagenta, false);
+    this.redrawActionButton(this.backButton, this.neonRed);
+    this.redrawActionButton(this.enterButton, this.neonGreen);
 
-    // Initially hide if not touch device
     this.container.visible = this.isTouchDevice;
     this._visible = this.isTouchDevice;
 
@@ -97,247 +136,324 @@ export class TouchControls {
     );
   }
 
-  private createActionButton(label: string, color: number, onTap: () => void): Container {
-    const btn = new Container();
-    const bg = new Graphics();
-    bg.beginFill(0x1a1a1a, 0.7);
-    bg.drawRoundedRect(-this.actionButtonWidth / 2, -this.actionButtonHeight / 2,
-      this.actionButtonWidth, this.actionButtonHeight, 8);
-    bg.endFill();
-    bg.lineStyle(2, color, 0.7);
-    bg.drawRoundedRect(-this.actionButtonWidth / 2, -this.actionButtonHeight / 2,
-      this.actionButtonWidth, this.actionButtonHeight, 8);
-    btn.addChild(bg);
-
+  private createControlButton(label: string, color: number): ControlButtonRefs {
+    const container = new Container();
+    const background = new Graphics();
     const text = new Text({
       text: label,
       style: new TextStyle({
         fontFamily: 'monospace',
-        fontSize: 14,
+        fontSize: 16,
+        fontWeight: 'bold',
+        fill: color,
+        align: 'center',
+      }),
+    });
+    text.anchor.set(0.5, 0.5);
+
+    container.addChild(background, text);
+    return { container, background, label: text };
+  }
+
+  private createActionButton(label: string, color: number, onTap: () => void): ActionButtonRefs {
+    const container = new Container();
+    const background = new Graphics();
+    const text = new Text({
+      text: label,
+      style: new TextStyle({
+        fontFamily: 'monospace',
+        fontSize: 16,
         fontWeight: 'bold',
         fill: color,
       }),
     });
     text.anchor.set(0.5, 0.5);
-    btn.addChild(text);
 
-    bg.eventMode = 'static';
-    bg.cursor = 'pointer';
-    bg.on('pointerdown', () => onTap());
+    background.eventMode = 'static';
+    background.cursor = 'pointer';
+    background.on('pointertap', () => onTap());
 
-    return btn;
+    container.addChild(background, text);
+    return { container, background, label: text };
   }
 
-  private setupJoystick(): void {
-    // Joystick base (outer circle)
-    this.joystickBase.beginFill(0x1a1a1a, 0.6);
-    this.joystickBase.drawCircle(0, 0, this.joystickRadius);
+  private redrawJoystick(): void {
+    this.joystickBase.clear();
+    this.joystickBase.beginFill(0x09141b, 0.78);
+    this.joystickBase.drawCircle(0, 0, this.joystickBaseRadius);
     this.joystickBase.endFill();
+    this.joystickBase.beginFill(this.neonCyan, 0.08);
+    this.joystickBase.drawCircle(0, 0, this.joystickBaseRadius - 6);
+    this.joystickBase.endFill();
+    this.joystickBase.lineStyle(3, this.neonCyan, 0.55);
+    this.joystickBase.drawCircle(0, 0, this.joystickBaseRadius);
+    this.joystickBase.lineStyle(1, this.neonCyan, 0.22);
+    this.joystickBase.drawCircle(0, 0, this.joystickBaseRadius * 0.7);
+    this.joystickBase.moveTo(-this.joystickBaseRadius * 0.55, 0);
+    this.joystickBase.lineTo(this.joystickBaseRadius * 0.55, 0);
+    this.joystickBase.moveTo(0, -this.joystickBaseRadius * 0.55);
+    this.joystickBase.lineTo(0, this.joystickBaseRadius * 0.55);
+    this.joystickBase.hitArea = new Circle(0, 0, this.joystickBaseRadius + 16);
 
-    this.joystickBase.lineStyle(2, this.neonCyan, 0.4);
-    this.joystickBase.drawCircle(0, 0, this.joystickRadius);
-
-    // Direction indicators
-    this.joystickBase.lineStyle(1, this.neonCyan, 0.3);
-    // Up arrow
-    this.joystickBase.moveTo(0, -this.joystickRadius + 15);
-    this.joystickBase.lineTo(-5, -this.joystickRadius + 22);
-    this.joystickBase.moveTo(0, -this.joystickRadius + 15);
-    this.joystickBase.lineTo(5, -this.joystickRadius + 22);
-    // Down arrow
-    this.joystickBase.moveTo(0, this.joystickRadius - 15);
-    this.joystickBase.lineTo(-5, this.joystickRadius - 22);
-    this.joystickBase.moveTo(0, this.joystickRadius - 15);
-    this.joystickBase.lineTo(5, this.joystickRadius - 22);
-
-    // Joystick knob
-    this.joystickKnob.beginFill(this.neonCyan, 0.3);
-    this.joystickKnob.drawCircle(0, 0, this.knobRadius);
+    this.joystickKnob.clear();
+    this.joystickKnob.beginFill(this.neonCyan, 0.28);
+    this.joystickKnob.drawCircle(0, 0, this.joystickKnobRadius);
     this.joystickKnob.endFill();
-
-    this.joystickKnob.lineStyle(2, this.neonCyan, 0.8);
-    this.joystickKnob.drawCircle(0, 0, this.knobRadius);
-
-    // Inner knob highlight
-    this.joystickKnob.beginFill(this.neonCyan, 0.5);
-    this.joystickKnob.drawCircle(0, 0, this.knobRadius * 0.4);
+    this.joystickKnob.beginFill(this.neonCyan, 0.55);
+    this.joystickKnob.drawCircle(0, 0, this.joystickKnobRadius * 0.42);
     this.joystickKnob.endFill();
+    this.joystickKnob.lineStyle(3, this.neonCyan, 0.9);
+    this.joystickKnob.drawCircle(0, 0, this.joystickKnobRadius);
 
-    this.joystickContainer.addChild(this.joystickBase);
-    this.joystickContainer.addChild(this.joystickKnob);
-
-    // Make interactive
-    this.joystickBase.eventMode = 'static';
-    this.joystickBase.cursor = 'pointer';
+    this.joystickHint.style.fontSize = Math.max(12, Math.round(this.joystickBaseRadius * 0.24));
+    this.joystickHint.position.set(0, this.joystickBaseRadius + 18);
   }
 
-  private setupButtons(): void {
-    // Brake button (red)
-    this.drawButton(this.brakeButton, this.neonRed, 'B', false);
+  private redrawControlButton(button: ControlButtonRefs, color: number, active: boolean): void {
+    const alpha = active ? 0.92 : 0.5;
 
-    // Handbrake button (magenta)
-    this.drawButton(this.handbrakeButton, this.neonMagenta, 'H', false);
+    button.background.clear();
+    button.background.beginFill(0x120d14, 0.82);
+    button.background.drawCircle(0, 0, this.buttonRadius);
+    button.background.endFill();
 
-    // Make interactive
-    this.brakeButton.eventMode = 'static';
-    this.brakeButton.cursor = 'pointer';
-    this.handbrakeButton.eventMode = 'static';
-    this.handbrakeButton.cursor = 'pointer';
-  }
-
-  private drawButton(graphics: Graphics, color: number, _label: string, active: boolean): void {
-    graphics.clear();
-
-    const alpha = active ? 0.7 : 0.4;
-    const borderAlpha = active ? 1.0 : 0.5;
-
-    // Button background
-    graphics.beginFill(0x1a1a1a, 0.6);
-    graphics.drawCircle(0, 0, this.buttonRadius);
-    graphics.endFill();
-
-    // Colored fill when active
     if (active) {
-      graphics.beginFill(color, 0.3);
-      graphics.drawCircle(0, 0, this.buttonRadius - 4);
-      graphics.endFill();
+      button.background.beginFill(color, 0.22);
+      button.background.drawCircle(0, 0, this.buttonRadius - 6);
+      button.background.endFill();
     }
 
-    // Border
-    graphics.lineStyle(3, color, borderAlpha);
-    graphics.drawCircle(0, 0, this.buttonRadius);
+    button.background.lineStyle(3, color, alpha);
+    button.background.drawCircle(0, 0, this.buttonRadius);
+    button.background.lineStyle(1, color, 0.35);
+    button.background.drawCircle(0, 0, this.buttonRadius * 0.68);
 
-    // Inner ring
-    graphics.lineStyle(1, color, alpha * 0.5);
-    graphics.drawCircle(0, 0, this.buttonRadius * 0.6);
+    button.label.style.fontSize = Math.max(13, Math.round(this.buttonRadius * 0.34));
+    button.container.hitArea = new Circle(0, 0, this.buttonRadius + 14);
+  }
+
+  private redrawActionButton(button: ActionButtonRefs, color: number): void {
+    const radius = Math.min(16, Math.round(this.actionButtonHeight * 0.3));
+
+    button.background.clear();
+    button.background.beginFill(0x090d18, 0.9);
+    button.background.drawRoundedRect(
+      -this.actionButtonWidth / 2,
+      -this.actionButtonHeight / 2,
+      this.actionButtonWidth,
+      this.actionButtonHeight,
+      radius
+    );
+    button.background.endFill();
+    button.background.lineStyle(2, color, 0.7);
+    button.background.drawRoundedRect(
+      -this.actionButtonWidth / 2,
+      -this.actionButtonHeight / 2,
+      this.actionButtonWidth,
+      this.actionButtonHeight,
+      radius
+    );
+    button.background.hitArea = new RoundedRectangle(
+      -this.actionButtonWidth / 2,
+      -this.actionButtonHeight / 2,
+      this.actionButtonWidth,
+      this.actionButtonHeight,
+      radius
+    );
+
+    button.label.style.fontSize = Math.max(15, Math.round(this.actionButtonHeight * 0.34));
   }
 
   private setupEventListeners(): void {
-    // Joystick events
-    this.joystickBase.on('pointerdown', this.onJoystickDown.bind(this));
-    this.joystickBase.on('pointermove', this.onJoystickMove.bind(this));
-    this.joystickBase.on('pointerup', this.onJoystickUp.bind(this));
-    this.joystickBase.on('pointerupoutside', this.onJoystickUp.bind(this));
+    this.joystickBase.eventMode = 'static';
+    this.joystickBase.cursor = 'pointer';
+    this.joystickBase.on('pointerdown', this.onJoystickDown);
 
-    // Brake button events
-    this.brakeButton.on('pointerdown', this.onBrakeDown.bind(this));
-    this.brakeButton.on('pointerup', this.onBrakeUp.bind(this));
-    this.brakeButton.on('pointerupoutside', this.onBrakeUp.bind(this));
+    this.brakeButton.container.eventMode = 'static';
+    this.brakeButton.container.cursor = 'pointer';
+    this.brakeButton.container.on('pointerdown', this.onBrakeDown);
 
-    // Handbrake button events
-    this.handbrakeButton.on('pointerdown', this.onHandbrakeDown.bind(this));
-    this.handbrakeButton.on('pointerup', this.onHandbrakeUp.bind(this));
-    this.handbrakeButton.on('pointerupoutside', this.onHandbrakeUp.bind(this));
+    this.handbrakeButton.container.eventMode = 'static';
+    this.handbrakeButton.container.cursor = 'pointer';
+    this.handbrakeButton.container.on('pointerdown', this.onHandbrakeDown);
+
+    window.addEventListener('pointermove', this.onGlobalPointerMove, { passive: false });
+    window.addEventListener('pointerup', this.onGlobalPointerEnd, { passive: false });
+    window.addEventListener('pointercancel', this.onGlobalPointerEnd, { passive: false });
   }
 
-  private onJoystickDown(event: FederatedPointerEvent): void {
-    this.joystickActive = true;
+  private onJoystickDown = (event: FederatedPointerEvent): void => {
+    if (this.joystickTouchId !== null && this.joystickTouchId !== event.pointerId) {
+      return;
+    }
+
     this.joystickTouchId = event.pointerId;
-    this.updateJoystickPosition(event);
+    this.updateJoystickFromScreenPoint(event.global.x, event.global.y);
+    event.stopPropagation();
+  };
+
+  private onBrakeDown = (event: FederatedPointerEvent): void => {
+    if (this.brakeTouchId !== null && this.brakeTouchId !== event.pointerId) {
+      return;
+    }
+
+    this.brakeTouchId = event.pointerId;
+    this.redrawControlButton(this.brakeButton, this.neonRed, true);
+    event.stopPropagation();
+  };
+
+  private onHandbrakeDown = (event: FederatedPointerEvent): void => {
+    if (this.handbrakeTouchId !== null && this.handbrakeTouchId !== event.pointerId) {
+      return;
+    }
+
+    this.handbrakeTouchId = event.pointerId;
+    this.redrawControlButton(this.handbrakeButton, this.neonMagenta, true);
+    event.stopPropagation();
+  };
+
+  private onGlobalPointerMove = (event: PointerEvent): void => {
+    if (event.pointerId !== this.joystickTouchId) {
+      return;
+    }
+
+    this.updateJoystickFromScreenPoint(event.clientX, event.clientY);
+    event.preventDefault();
+  };
+
+  private onGlobalPointerEnd = (event: PointerEvent): void => {
+    if (event.pointerId === this.joystickTouchId) {
+      this.resetJoystick();
+    }
+
+    if (event.pointerId === this.brakeTouchId) {
+      this.brakeTouchId = null;
+      this.redrawControlButton(this.brakeButton, this.neonRed, false);
+    }
+
+    if (event.pointerId === this.handbrakeTouchId) {
+      this.handbrakeTouchId = null;
+      this.redrawControlButton(this.handbrakeButton, this.neonMagenta, false);
+    }
+  };
+
+  private updateJoystickFromScreenPoint(x: number, y: number): void {
+    const localX = x - this.joystickCenter.x;
+    const localY = y - this.joystickCenter.y;
+    const distance = Math.sqrt(localX * localX + localY * localY);
+    const maxDistance = this.joystickBaseRadius - this.joystickKnobRadius * 0.45;
+
+    let knobX = localX;
+    let knobY = localY;
+    if (distance > maxDistance && distance > 0) {
+      const scale = maxDistance / distance;
+      knobX *= scale;
+      knobY *= scale;
+    }
+
+    this.joystickKnob.position.set(knobX, knobY);
+    this.joystickOffset = {
+      x: knobX / maxDistance,
+      y: knobY / maxDistance,
+    };
   }
 
-  private onJoystickMove(event: FederatedPointerEvent): void {
-    if (!this.joystickActive || event.pointerId !== this.joystickTouchId) return;
-    this.updateJoystickPosition(event);
-  }
-
-  private onJoystickUp(event: FederatedPointerEvent): void {
-    if (event.pointerId !== this.joystickTouchId) return;
-    this.joystickActive = false;
+  private resetJoystick(): void {
     this.joystickTouchId = null;
     this.joystickOffset = { x: 0, y: 0 };
     this.joystickKnob.position.set(0, 0);
   }
 
-  private updateJoystickPosition(event: FederatedPointerEvent): void {
-    const localPos = this.joystickContainer.toLocal(event.global);
-
-    // Clamp to joystick radius
-    const distance = Math.sqrt(localPos.x * localPos.x + localPos.y * localPos.y);
-    const maxDistance = this.joystickRadius - this.knobRadius * 0.5;
-
-    if (distance > maxDistance) {
-      const scale = maxDistance / distance;
-      localPos.x *= scale;
-      localPos.y *= scale;
+  private applyDeadzone(value: number, deadzone: number): number {
+    const magnitude = Math.abs(value);
+    if (magnitude <= deadzone) {
+      return 0;
     }
 
-    this.joystickKnob.position.set(localPos.x, localPos.y);
-
-    // Normalize to -1 to 1
-    this.joystickOffset = {
-      x: localPos.x / maxDistance,
-      y: localPos.y / maxDistance,
-    };
+    const normalized = (magnitude - deadzone) / (1 - deadzone);
+    return Math.sign(value) * clamp(normalized, 0, 1);
   }
 
-  private onBrakeDown(): void {
-    this.brakeActive = true;
-    this.drawButton(this.brakeButton, this.neonRed, 'B', true);
-  }
+  private updateMetrics(screenWidth: number, screenHeight: number): void {
+    const shortSide = Math.min(screenWidth, screenHeight);
+    const portraitScale = clamp(shortSide / 390, 0.92, 1.12);
+    const compactScale = screenWidth > screenHeight ? 0.9 : 1;
+    const controlScale = portraitScale * compactScale;
 
-  private onBrakeUp(): void {
-    this.brakeActive = false;
-    this.drawButton(this.brakeButton, this.neonRed, 'B', false);
-  }
-
-  private onHandbrakeDown(): void {
-    this.handbrakeActive = true;
-    this.drawButton(this.handbrakeButton, this.neonMagenta, 'H', true);
-  }
-
-  private onHandbrakeUp(): void {
-    this.handbrakeActive = false;
-    this.drawButton(this.handbrakeButton, this.neonMagenta, 'H', false);
+    this.joystickBaseRadius = Math.round(70 * controlScale);
+    this.joystickKnobRadius = Math.round(30 * controlScale);
+    this.buttonRadius = Math.round(46 * controlScale);
+    this.actionButtonWidth = Math.max(88, Math.round(104 * controlScale));
+    this.actionButtonHeight = Math.max(44, Math.round(48 * controlScale));
+    this.controlPadding = Math.round(clamp(shortSide * 0.05, 16, 28));
+    this.bottomPadding = Math.round(clamp(screenHeight * 0.035, 20, 34));
   }
 
   getInput(): TouchInput {
-    if (!this.joystickActive && !this.brakeActive && !this.handbrakeActive) {
-      return { throttle: 0, brake: 0, steer: 0, handbrake: 0 };
-    }
-
-    // Joystick Y axis: up = throttle, down = brake (additional to button)
-    const throttle = clamp(-this.joystickOffset.y, 0, 1);
-    const joystickBrake = clamp(this.joystickOffset.y, 0, 1);
-
-    // Joystick X axis: steering
-    const steer = clamp(this.joystickOffset.x, -1, 1);
+    const steer = this.applyDeadzone(this.joystickOffset.x, 0.12);
+    const driveAxis = this.applyDeadzone(this.joystickOffset.y, 0.08);
 
     return {
-      throttle,
-      brake: Math.max(joystickBrake, this.brakeActive ? 1 : 0),
+      throttle: clamp(-driveAxis, 0, 1),
+      brake: Math.max(clamp(driveAxis, 0, 1), this.brakeTouchId !== null ? 1 : 0),
       steer,
-      handbrake: this.handbrakeActive ? 1 : 0,
+      handbrake: this.handbrakeTouchId !== null ? 1 : 0,
     };
   }
 
-  /** Show or hide the action buttons (BACK / GO). */
   showActionButtons(show: boolean): void {
-    this.backButton.visible = show && this.isTouchDevice;
-    this.enterButton.visible = show && this.isTouchDevice;
+    this.setActionButtonVisibility(show, show);
+  }
+
+  setActionButtonVisibility(backVisible: boolean, enterVisible: boolean): void {
+    this.backButtonVisible = backVisible;
+    this.enterButtonVisible = enterVisible;
+    this.backButton.container.visible = backVisible && this.isTouchDevice;
+    this.enterButton.container.visible = enterVisible && this.isTouchDevice;
   }
 
   setPosition(screenWidth: number, screenHeight: number): void {
-    // Joystick on left side, near bottom
-    this.joystickContainer.position.set(
-      this.joystickRadius + 30,
-      screenHeight - this.joystickRadius - 80
-    );
+    this.screenWidth = screenWidth;
+    this.screenHeight = screenHeight;
+    this.updateMetrics(screenWidth, screenHeight);
 
-    // Buttons on right side, stacked vertically
-    this.brakeButton.position.set(
-      screenWidth - this.buttonRadius - 30,
-      screenHeight - this.buttonRadius - 80
-    );
+    this.redrawJoystick();
+    this.redrawControlButton(this.brakeButton, this.neonRed, this.brakeTouchId !== null);
+    this.redrawControlButton(this.handbrakeButton, this.neonMagenta, this.handbrakeTouchId !== null);
+    this.redrawActionButton(this.backButton, this.neonRed);
+    this.redrawActionButton(this.enterButton, this.neonGreen);
 
-    this.handbrakeButton.position.set(
-      screenWidth - this.buttonRadius - 30,
-      screenHeight - this.buttonRadius * 3 - 100
-    );
+    const isMobile = screenWidth < 768;
+    const controlColumnGap = Math.round(this.buttonRadius * 2.25);
 
-    // Action buttons: top corners
-    this.backButton.position.set(50, 30);
-    this.enterButton.position.set(screenWidth - 50, 30);
+    this.joystickCenter = {
+      x: this.controlPadding + this.joystickBaseRadius,
+      y: screenHeight - this.bottomPadding - this.joystickBaseRadius,
+    };
+    this.joystickContainer.position.set(this.joystickCenter.x, this.joystickCenter.y);
+
+    const brakeX = screenWidth - this.controlPadding - this.buttonRadius;
+    const brakeY = screenHeight - this.bottomPadding - this.buttonRadius;
+    this.brakeButton.container.position.set(brakeX, brakeY);
+    this.handbrakeButton.container.position.set(brakeX, brakeY - controlColumnGap);
+
+    if (isMobile) {
+      this.backButton.container.position.set(
+        this.joystickCenter.x,
+        this.joystickCenter.y - this.joystickBaseRadius - this.actionButtonHeight * 0.6
+      );
+      this.enterButton.container.position.set(
+        brakeX,
+        brakeY - controlColumnGap - this.buttonRadius - this.actionButtonHeight * 0.75
+      );
+    } else {
+      const topY = this.controlPadding + this.actionButtonHeight / 2;
+      this.backButton.container.position.set(this.controlPadding + this.actionButtonWidth / 2, topY);
+      this.enterButton.container.position.set(screenWidth - this.controlPadding - this.actionButtonWidth / 2, topY);
+    }
+
+    this.backButton.container.visible = this.backButtonVisible && this.isTouchDevice;
+    this.enterButton.container.visible = this.enterButtonVisible && this.isTouchDevice;
   }
 
   get visible(): boolean {

--- a/src/utils/viewport.ts
+++ b/src/utils/viewport.ts
@@ -1,0 +1,13 @@
+export interface ViewportSize {
+  width: number;
+  height: number;
+}
+
+export function getViewportSize(): ViewportSize {
+  const viewport = window.visualViewport;
+
+  return {
+    width: Math.round(viewport?.width ?? window.innerWidth),
+    height: Math.round(viewport?.height ?? window.innerHeight),
+  };
+}


### PR DESCRIPTION
Fixes #21

## Changes

**Touch Controls (complete rewrite):**
- Larger joystick (70px base) and buttons (46px radius) with proper hit areas (+14px padding)
- Per-pointer tracking for simultaneous steer+brake+handbrake (multi-touch)
- Global pointer move/up listeners — no more lost touches when finger slides off button
- Deadzone filtering (12% steer, 8% throttle) to prevent drift
- Labels: B→BRAKE, H→DRIFT, with "STEER / GAS" hint on joystick
- Dynamic scaling based on shortest screen dimension

**Responsive Layout:**
- New `getViewportSize()` utility using `visualViewport` API (handles mobile keyboard/toolbar resize)
- HUD scales from reference 430×932 with separate timer/overlay scale factors
- Menu buttons get proper rounded-rect backgrounds with neon borders
- Title splits to two lines on phones (<560px)
- Controls overlay uses a card layout with proper font scaling
- Music controls switch to compact mode on mobile with 44px touch targets
- Minimap scales 0.68–0.92× on mobile, positions below don't overlap

**Other fixes:**
- `overscroll-behavior: none` on body to prevent pull-to-refresh
- Dialogue box tappable to advance (mobile story mode)
- GO button only shows during relevant game states
- Minimap hidden when not racing
- DriftPhase enum comparison fix