### PR TITLE
fix: unique audio tracks, overlay z-index, AI difficulty options

### DIFF
--- a/src/ai/BotDriver.ts
+++ b/src/ai/BotDriver.ts
@@ -25,12 +25,22 @@ export class BotDriver {
   readonly personality: BotPersonality;
   currentCheckpointIndex = 0;
 
+  /** Difficulty multiplier applied to speed and rubber-banding. */
+  private speedMultiplier = 1.0;
+  private rubberBandMultiplier = 1.0;
+
   /** Accumulated random wander offset — makes bots imperfect. */
   private wanderOffset = 0;
   private wanderTimer = 0;
 
   constructor(personality: BotPersonality) {
     this.personality = personality;
+  }
+
+  /** Apply difficulty scaling to this bot driver. */
+  setDifficulty(speedMultiplier: number, rubberBandMultiplier: number): void {
+    this.speedMultiplier = speedMultiplier;
+    this.rubberBandMultiplier = rubberBandMultiplier;
   }
 
   /**
@@ -108,18 +118,18 @@ export class BotDriver {
       brake = 0;
     }
 
-    // Rubber-banding
+    // Rubber-banding (scaled by difficulty)
     const progressDiff = leaderProgress - ownProgress;
     let rubberBand = 1.0;
     if (progressDiff > 1) {
       // Behind the leader — boost
-      rubberBand = 1.0 + Math.min(progressDiff * 0.06, 0.25);
+      rubberBand = 1.0 + Math.min(progressDiff * 0.06 * this.rubberBandMultiplier, 0.25 * this.rubberBandMultiplier);
     } else if (progressDiff < -1) {
       // Ahead of everyone — slow down slightly
       rubberBand = 1.0 - Math.min(Math.abs(progressDiff) * 0.04, 0.15);
     }
 
-    throttle *= this.personality.speedFactor * rubberBand;
+    throttle *= this.personality.speedFactor * this.speedMultiplier * rubberBand;
     throttle = clamp(throttle, 0, 1);
 
     return { throttle, brake, steer, handbrake: 0 };

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -19,6 +19,14 @@ interface ProceduralMusicTrack extends MusicTrackInfo {
   bpm: number;
   leadPattern: number[];
   bassPattern: number[];
+  /** Oscillator waveform for the lead voice. */
+  leadWave: OscillatorType;
+  /** Oscillator waveform for the bass voice. */
+  bassWave: OscillatorType;
+  /** Lead voice gain multiplier (default baseline is 0.085). */
+  leadGain: number;
+  /** Bass voice gain multiplier (default baseline is 0.05). */
+  bassGain: number;
 }
 
 export class AudioManager {
@@ -61,6 +69,10 @@ export class AudioManager {
       bpm: 132,
       leadPattern: [440, 494, 554, 659, 554, 494, 440, 392, 440, 494, 554, 659, 587, 523, 440, 0],
       bassPattern: [110, 110, 123, 123, 139, 139, 123, 123, 110, 110, 98, 98, 82, 82, 98, 0],
+      leadWave: 'triangle',
+      bassWave: 'sine',
+      leadGain: 0.09,
+      bassGain: 0.06,
     },
     {
       id: 'chrome-highway',
@@ -68,6 +80,10 @@ export class AudioManager {
       bpm: 122,
       leadPattern: [523, 587, 659, 698, 659, 587, 523, 466, 523, 587, 659, 698, 659, 587, 523, 0],
       bassPattern: [98, 98, 98, 98, 123, 123, 123, 123, 110, 110, 110, 110, 82, 82, 82, 0],
+      leadWave: 'sawtooth',
+      bassWave: 'square',
+      leadGain: 0.065,
+      bassGain: 0.045,
     },
     {
       id: 'neon-midnight',
@@ -75,6 +91,10 @@ export class AudioManager {
       bpm: 138,
       leadPattern: [349, 392, 440, 392, 523, 440, 392, 349, 392, 440, 494, 440, 523, 587, 440, 0],
       bassPattern: [87, 87, 87, 87, 110, 110, 110, 110, 98, 98, 98, 98, 73, 73, 73, 0],
+      leadWave: 'square',
+      bassWave: 'triangle',
+      leadGain: 0.07,
+      bassGain: 0.055,
     },
   ];
 
@@ -356,11 +376,15 @@ export class AudioManager {
     const bassNote = track.bassPattern[this.musicStep % track.bassPattern.length] ?? 0;
     const smooth = forceImmediate ? 0.001 : 0.025;
 
+    // Apply per-track waveforms so each track sounds distinct
+    this.musicLeadOsc.type = track.leadWave;
+    this.musicBassOsc.type = track.bassWave;
+
     this.musicLeadOsc.frequency.setTargetAtTime(Math.max(leadNote, 35), now, smooth);
     this.musicBassOsc.frequency.setTargetAtTime(Math.max(bassNote, 35), now, smooth);
 
-    const leadTarget = this._musicPlaying && leadNote > 0 ? 0.085 : 0;
-    const bassTarget = this._musicPlaying && bassNote > 0 ? 0.05 : 0;
+    const leadTarget = this._musicPlaying && leadNote > 0 ? track.leadGain : 0;
+    const bassTarget = this._musicPlaying && bassNote > 0 ? track.bassGain : 0;
     this.musicLeadGain.gain.setTargetAtTime(leadTarget, now, smooth);
     this.musicBassGain.gain.setTargetAtTime(bassTarget, now, smooth);
   }

--- a/src/game/Difficulty.ts
+++ b/src/game/Difficulty.ts
@@ -1,0 +1,32 @@
+/** Difficulty presets that scale AI bot competitiveness. */
+export enum Difficulty {
+  EASY = 'EASY',
+  NORMAL = 'NORMAL',
+  HARD = 'HARD',
+}
+
+export interface DifficultyConfig {
+  label: string;
+  /** Multiplier applied to bot speedFactor (higher = faster bots). */
+  botSpeedMultiplier: number;
+  /** Multiplier applied to rubber-band boost when behind leader. */
+  rubberBandMultiplier: number;
+}
+
+export const DIFFICULTY_CONFIGS: Record<Difficulty, DifficultyConfig> = {
+  [Difficulty.EASY]: {
+    label: 'Easy',
+    botSpeedMultiplier: 0.82,
+    rubberBandMultiplier: 0.5,
+  },
+  [Difficulty.NORMAL]: {
+    label: 'Normal',
+    botSpeedMultiplier: 1.0,
+    rubberBandMultiplier: 1.0,
+  },
+  [Difficulty.HARD]: {
+    label: 'Hard',
+    botSpeedMultiplier: 1.12,
+    rubberBandMultiplier: 1.5,
+  },
+};

--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -32,6 +32,7 @@ import type { StoryState } from '../story/Mission';
 import { DialogueBox } from '../story/DialogueBox';
 import { STORY_MISSIONS } from '../story/StoryContent';
 import { getViewportSize } from '../utils/viewport';
+import { Difficulty, DIFFICULTY_CONFIGS } from './Difficulty';
 
 export class Game {
   private app: Application;
@@ -67,6 +68,7 @@ export class Game {
   // AI bots
   private bots: BotVehicle[] = [];
   private standings: RaceStandings;
+  private difficulty: Difficulty = Difficulty.NORMAL;
   private playerFinished = false;
   private playerFinishTime: number | null = null;
 
@@ -194,8 +196,9 @@ export class Game {
     });
 
     // Add UI elements (on top of world and lighting)
-    this.uiContainer.addChild(this.hud.container);
+    // MiniMap is added first so HUD overlays (standings, position, race overlay) render on top of it
     this.uiContainer.addChild(this.miniMap.container);
+    this.uiContainer.addChild(this.hud.container);
     this.uiContainer.addChild(this.touchControls.container);
     this.uiContainer.addChild(this.musicControls.container);
     this.app.stage.addChild(this.uiContainer);
@@ -395,11 +398,25 @@ export class Game {
     this.uiContainer.visible = visible;
   }
 
+  /** Set the AI difficulty level. Applies to all bots immediately. */
+  setDifficulty(difficulty: Difficulty): void {
+    this.difficulty = difficulty;
+    this.applyDifficultyToBots();
+  }
+
+  private applyDifficultyToBots(): void {
+    const config = DIFFICULTY_CONFIGS[this.difficulty];
+    for (const bot of this.bots) {
+      bot.driver.setDifficulty(config.botSpeedMultiplier, config.rubberBandMultiplier);
+    }
+  }
+
   private createBots(): void {
     for (let i = 0; i < BOT_PERSONALITIES.length; i++) {
       const bot = new BotVehicle(BOT_PERSONALITIES[i], BOT_COLORS[i]);
       this.bots.push(bot);
     }
+    this.applyDifficultyToBots();
     this.resetBots();
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { Game } from './game/Game';
 import { GameModeManager, GameMode } from './game/GameModeManager';
 import { MainMenu } from './ui/MainMenu';
 import { getViewportSize } from './utils/viewport';
+import { Difficulty } from './game/Difficulty';
 
 const root = document.getElementById('app');
 if (!root) {
@@ -22,10 +23,13 @@ app
 
     const modeManager = new GameModeManager();
 
+    let pendingDifficulty: Difficulty = Difficulty.NORMAL;
+
     const menu = new MainMenu({
       onQuickRace: () => modeManager.startQuickRace(),
       onStoryMode: () => modeManager.startStory(),
       onControls: () => modeManager.showControls(),
+      onDifficultyChange: (d: Difficulty) => { pendingDifficulty = d; },
     });
 
     app.stage.addChild(menu.container);
@@ -45,10 +49,12 @@ app
           break;
         case GameMode.PLAYING:
           menu.container.visible = false;
+          game.setDifficulty(pendingDifficulty);
           game.start();
           break;
         case GameMode.STORY:
           menu.container.visible = false;
+          game.setDifficulty(pendingDifficulty);
           game.startStory();
           break;
         case GameMode.CONTROLS:

--- a/src/ui/MainMenu.ts
+++ b/src/ui/MainMenu.ts
@@ -1,9 +1,11 @@
 import { Container, Graphics, Text, TextStyle } from 'pixi.js';
+import { Difficulty, DIFFICULTY_CONFIGS } from '../game/Difficulty';
 
 export interface MainMenuCallbacks {
   onQuickRace: () => void;
   onStoryMode: () => void;
   onControls: () => void;
+  onDifficultyChange?: (difficulty: Difficulty) => void;
 }
 
 interface MenuItem {
@@ -51,6 +53,15 @@ export class MainMenu {
 
   private particleGraphics: Graphics;
   private particles: Particle[] = [];
+
+  private difficultyContainer: Container;
+  private difficultyLabel: Text;
+  private difficultyValue: Text;
+  private difficultyLeftArrow: Text;
+  private difficultyRightArrow: Text;
+  private difficultyBg: Graphics;
+  private currentDifficulty: Difficulty = Difficulty.NORMAL;
+  private readonly difficultyOrder: Difficulty[] = [Difficulty.EASY, Difficulty.NORMAL, Difficulty.HARD];
 
   private callbacks: MainMenuCallbacks;
   private screenWidth = 0;
@@ -104,6 +115,56 @@ export class MainMenu {
     this.createMenuItem('QUICK RACE', () => this.callbacks.onQuickRace());
     this.createMenuItem('STORY MODE', () => this.handleStoryMode());
     this.createMenuItem('CONTROLS', () => this.callbacks.onControls());
+
+    // Difficulty selector
+    this.difficultyContainer = new Container();
+    this.difficultyBg = new Graphics();
+    this.difficultyLabel = new Text({
+      text: 'DIFFICULTY',
+      style: new TextStyle({
+        fontFamily: 'monospace',
+        fontSize: 13,
+        fill: 0x888888,
+      }),
+    });
+    this.difficultyLabel.anchor.set(0.5, 0.5);
+
+    this.difficultyLeftArrow = new Text({
+      text: '◀',
+      style: new TextStyle({ fontFamily: 'monospace', fontSize: 22, fontWeight: 'bold', fill: NEON_CYAN }),
+    });
+    this.difficultyLeftArrow.anchor.set(0.5, 0.5);
+    this.difficultyLeftArrow.eventMode = 'static';
+    this.difficultyLeftArrow.cursor = 'pointer';
+    this.difficultyLeftArrow.on('pointertap', () => this.cycleDifficulty(-1));
+
+    this.difficultyRightArrow = new Text({
+      text: '▶',
+      style: new TextStyle({ fontFamily: 'monospace', fontSize: 22, fontWeight: 'bold', fill: NEON_CYAN }),
+    });
+    this.difficultyRightArrow.anchor.set(0.5, 0.5);
+    this.difficultyRightArrow.eventMode = 'static';
+    this.difficultyRightArrow.cursor = 'pointer';
+    this.difficultyRightArrow.on('pointertap', () => this.cycleDifficulty(1));
+
+    this.difficultyValue = new Text({
+      text: DIFFICULTY_CONFIGS[this.currentDifficulty].label,
+      style: new TextStyle({
+        fontFamily: 'monospace',
+        fontSize: 22,
+        fontWeight: 'bold',
+        fill: NEON_MAGENTA,
+        dropShadow: { color: NEON_MAGENTA, blur: 8, distance: 0 },
+      }),
+    });
+    this.difficultyValue.anchor.set(0.5, 0.5);
+
+    this.difficultyContainer.addChild(this.difficultyBg);
+    this.difficultyContainer.addChild(this.difficultyLabel);
+    this.difficultyContainer.addChild(this.difficultyLeftArrow);
+    this.difficultyContainer.addChild(this.difficultyValue);
+    this.difficultyContainer.addChild(this.difficultyRightArrow);
+    this.container.addChild(this.difficultyContainer);
 
     this.toastText = new Text({
       text: 'Coming Soon...',
@@ -290,6 +351,14 @@ export class MainMenu {
       : false;
   }
 
+  private cycleDifficulty(direction: number): void {
+    const idx = this.difficultyOrder.indexOf(this.currentDifficulty);
+    const newIdx = (idx + direction + this.difficultyOrder.length) % this.difficultyOrder.length;
+    this.currentDifficulty = this.difficultyOrder[newIdx];
+    this.difficultyValue.text = DIFFICULTY_CONFIGS[this.currentDifficulty].label;
+    this.callbacks.onDifficultyChange?.(this.currentDifficulty);
+  }
+
   private handleStoryMode(): void {
     this.callbacks.onStoryMode();
   }
@@ -299,6 +368,7 @@ export class MainMenu {
     this.controlsContainer.visible = true;
     this.titleText.visible = false;
     this.subtitleText.visible = false;
+    this.difficultyContainer.visible = false;
     for (const item of this.items) {
       item.container.visible = false;
     }
@@ -311,6 +381,7 @@ export class MainMenu {
     this.controlsContainer.visible = false;
     this.titleText.visible = true;
     this.subtitleText.visible = true;
+    this.difficultyContainer.visible = true;
     for (const item of this.items) {
       item.container.visible = true;
     }
@@ -413,8 +484,18 @@ export class MainMenu {
     }
     this.updateSelection();
 
+    // Difficulty selector positioned below menu items
+    const diffY = menuStartY + this.items.length * itemSpacing + 12;
+    this.difficultyContainer.position.set(cx, diffY);
+    this.difficultyLabel.position.set(0, -14);
+    this.difficultyLabel.style.fontSize = isPhone ? 11 : 13;
+    this.difficultyLeftArrow.position.set(-80, 10);
+    this.difficultyValue.position.set(0, 10);
+    this.difficultyValue.style.fontSize = isPhone ? 18 : 22;
+    this.difficultyRightArrow.position.set(80, 10);
+
     this.toastText.style.fontSize = isPhone ? 20 : 24;
-    this.toastText.position.set(cx, menuStartY + this.items.length * itemSpacing + 28);
+    this.toastText.position.set(cx, diffY + 50);
 
     if (this.showingControls) {
       this.layoutControls();


### PR DESCRIPTION
## Summary

Fixes all 3 parts of #31: unique audio tracks, overlay hidden behind map, and AI difficulty options.

## Changes

- **Audio tracks now sound distinct**: Each of the 3 music tracks uses different oscillator waveforms (triangle/sine for Sunset Run, sawtooth/square for Chrome Highway, square/triangle for Neon Midnight) and per-track gain levels. Previously all tracks used identical triangle+square waveforms.

- **HUD overlays now render on top of minimap**: Reordered UI container children in Game.ts so MiniMap is added first, then HUD. This ensures race standings, position display, and overlay screens render above the minimap instead of being hidden behind it.

- **Difficulty selector in main menu**: Added Easy/Normal/Hard difficulty option to the main menu with clickable arrows. Difficulty scales AI bot speed (0.82x to 1.12x) and rubber-band aggressiveness. New `Difficulty.ts` module with clean config, wired through `BotDriver.setDifficulty()` → `Game.setDifficulty()` → `MainMenu` callbacks.

## Files Changed

- `src/audio/AudioManager.ts` — Per-track waveform types and gain levels
- `src/game/Game.ts` — UI layering fix + difficulty integration
- `src/game/Difficulty.ts` — New difficulty config module
- `src/ai/BotDriver.ts` — Difficulty multipliers for speed/rubber-banding
- `src/ui/MainMenu.ts` — Difficulty selector UI
- `src/main.ts` — Wire difficulty from menu to game

## Testing

- `npm run build` ✅ (clean production build)
- `npx vitest run` ✅ (66/66 tests pass)

Fixes the911fund/neon-desert-outlaw#31